### PR TITLE
Implement keypad workflows for work orders and issue materials

### DIFF
--- a/app/src/main/java/com/example/terminal/IssueMaterialsActivity.kt
+++ b/app/src/main/java/com/example/terminal/IssueMaterialsActivity.kt
@@ -1,11 +1,127 @@
 package com.example.terminal
 
 import android.os.Bundle
+import android.widget.Button
+import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 
 class IssueMaterialsActivity : AppCompatActivity() {
+
+    private enum class InputTarget { EMPLOYEE, MATERIAL }
+
+    private val employeeBuilder = StringBuilder()
+    private val materialBuilder = StringBuilder()
+    private var activeTarget = InputTarget.EMPLOYEE
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_issue_materials)
+
+        val employeeValue = findViewById<TextView>(R.id.textIssueEmployeeValue)
+        val materialValue = findViewById<TextView>(R.id.textMaterialValue)
+        val activeInput = findViewById<TextView>(R.id.textIssueActiveInput)
+
+        val digitButtons = mapOf(
+            R.id.buttonKey0 to "0",
+            R.id.buttonKey1 to "1",
+            R.id.buttonKey2 to "2",
+            R.id.buttonKey3 to "3",
+            R.id.buttonKey4 to "4",
+            R.id.buttonKey5 to "5",
+            R.id.buttonKey6 to "6",
+            R.id.buttonKey7 to "7",
+            R.id.buttonKey8 to "8",
+            R.id.buttonKey9 to "9"
+        )
+
+        val updateDisplays = {
+            employeeValue.text = if (employeeBuilder.isEmpty()) {
+                getString(R.string.default_input_placeholder)
+            } else {
+                employeeBuilder.toString()
+            }
+
+            materialValue.text = if (materialBuilder.isEmpty()) {
+                getString(R.string.default_input_placeholder)
+            } else {
+                materialBuilder.toString()
+            }
+        }
+
+        val updateActiveIndicator = {
+            activeInput.text = when (activeTarget) {
+                InputTarget.EMPLOYEE -> getString(R.string.issue_materials_active_employee)
+                InputTarget.MATERIAL -> getString(R.string.issue_materials_active_material)
+            }
+
+            employeeValue.alpha = if (activeTarget == InputTarget.EMPLOYEE) 1f else 0.6f
+            materialValue.alpha = if (activeTarget == InputTarget.MATERIAL) 1f else 0.6f
+        }
+
+        employeeValue.setOnClickListener {
+            activeTarget = InputTarget.EMPLOYEE
+            updateActiveIndicator()
+        }
+
+        materialValue.setOnClickListener {
+            activeTarget = InputTarget.MATERIAL
+            updateActiveIndicator()
+        }
+
+        digitButtons.forEach { (buttonId, value) ->
+            findViewById<Button>(buttonId).setOnClickListener {
+                val builder = if (activeTarget == InputTarget.EMPLOYEE) employeeBuilder else materialBuilder
+                builder.append(value)
+                updateDisplays()
+            }
+        }
+
+        findViewById<Button>(R.id.buttonClear).setOnClickListener {
+            val builder = if (activeTarget == InputTarget.EMPLOYEE) employeeBuilder else materialBuilder
+            if (builder.isNotEmpty()) {
+                builder.deleteCharAt(builder.length - 1)
+                updateDisplays()
+            }
+        }
+
+        findViewById<Button>(R.id.buttonEnter).setOnClickListener {
+            activeTarget = when (activeTarget) {
+                InputTarget.EMPLOYEE -> InputTarget.MATERIAL
+                InputTarget.MATERIAL -> InputTarget.EMPLOYEE
+            }
+            updateActiveIndicator()
+        }
+
+        findViewById<Button>(R.id.buttonIssueMaterial).setOnClickListener {
+            handleIssueMaterial()
+        }
+
+        updateDisplays()
+        updateActiveIndicator()
+    }
+
+    private fun handleIssueMaterial() {
+        val employeeNumber = employeeBuilder.toString()
+        val materialCode = materialBuilder.toString()
+
+        if (employeeNumber.isBlank() || materialCode.isBlank()) {
+            Toast.makeText(
+                this,
+                getString(R.string.toast_enter_employee_and_material),
+                Toast.LENGTH_SHORT
+            ).show()
+            return
+        }
+
+        val materials = issuedMaterials.getOrPut(employeeNumber) { mutableListOf() }
+        materials.add(materialCode)
+
+        val message = getString(R.string.toast_issue_material, employeeNumber, materialCode)
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+    }
+
+    companion object {
+        private val issuedMaterials = mutableMapOf<String, MutableList<String>>()
     }
 }

--- a/app/src/main/java/com/example/terminal/WorkOrdersActivity.kt
+++ b/app/src/main/java/com/example/terminal/WorkOrdersActivity.kt
@@ -1,11 +1,140 @@
 package com.example.terminal
 
 import android.os.Bundle
+import android.widget.Button
+import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 
 class WorkOrdersActivity : AppCompatActivity() {
+
+    private enum class InputTarget { EMPLOYEE, WORK_ORDER }
+
+    private val employeeBuilder = StringBuilder()
+    private val workOrderBuilder = StringBuilder()
+    private var activeTarget = InputTarget.EMPLOYEE
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_work_orders)
+
+        val employeeValue = findViewById<TextView>(R.id.textEmployeeValue)
+        val workOrderValue = findViewById<TextView>(R.id.textWorkOrderValue)
+        val activeInput = findViewById<TextView>(R.id.textActiveInput)
+
+        val digitButtons = mapOf(
+            R.id.buttonKey0 to "0",
+            R.id.buttonKey1 to "1",
+            R.id.buttonKey2 to "2",
+            R.id.buttonKey3 to "3",
+            R.id.buttonKey4 to "4",
+            R.id.buttonKey5 to "5",
+            R.id.buttonKey6 to "6",
+            R.id.buttonKey7 to "7",
+            R.id.buttonKey8 to "8",
+            R.id.buttonKey9 to "9"
+        )
+
+        val updateDisplays = {
+            employeeValue.text = if (employeeBuilder.isEmpty()) {
+                getString(R.string.default_input_placeholder)
+            } else {
+                employeeBuilder.toString()
+            }
+
+            workOrderValue.text = if (workOrderBuilder.isEmpty()) {
+                getString(R.string.default_input_placeholder)
+            } else {
+                workOrderBuilder.toString()
+            }
+        }
+
+        val updateActiveIndicator = {
+            activeInput.text = when (activeTarget) {
+                InputTarget.EMPLOYEE -> getString(R.string.work_orders_active_employee)
+                InputTarget.WORK_ORDER -> getString(R.string.work_orders_active_work_order)
+            }
+
+            employeeValue.alpha = if (activeTarget == InputTarget.EMPLOYEE) 1f else 0.6f
+            workOrderValue.alpha = if (activeTarget == InputTarget.WORK_ORDER) 1f else 0.6f
+        }
+
+        employeeValue.setOnClickListener {
+            activeTarget = InputTarget.EMPLOYEE
+            updateActiveIndicator()
+        }
+
+        workOrderValue.setOnClickListener {
+            activeTarget = InputTarget.WORK_ORDER
+            updateActiveIndicator()
+        }
+
+        digitButtons.forEach { (buttonId, value) ->
+            findViewById<Button>(buttonId).setOnClickListener {
+                val builder = if (activeTarget == InputTarget.EMPLOYEE) employeeBuilder else workOrderBuilder
+                builder.append(value)
+                updateDisplays()
+            }
+        }
+
+        findViewById<Button>(R.id.buttonClear).setOnClickListener {
+            val builder = if (activeTarget == InputTarget.EMPLOYEE) employeeBuilder else workOrderBuilder
+            if (builder.isNotEmpty()) {
+                builder.deleteCharAt(builder.length - 1)
+                updateDisplays()
+            }
+        }
+
+        findViewById<Button>(R.id.buttonEnter).setOnClickListener {
+            activeTarget = when (activeTarget) {
+                InputTarget.EMPLOYEE -> InputTarget.WORK_ORDER
+                InputTarget.WORK_ORDER -> InputTarget.EMPLOYEE
+            }
+            updateActiveIndicator()
+        }
+
+        findViewById<Button>(R.id.buttonClockInWo).setOnClickListener {
+            handleClockAction(clockIn = true)
+        }
+
+        findViewById<Button>(R.id.buttonClockOutWo).setOnClickListener {
+            handleClockAction(clockIn = false)
+        }
+
+        updateDisplays()
+        updateActiveIndicator()
+    }
+
+    private fun handleClockAction(clockIn: Boolean) {
+        val employeeNumber = employeeBuilder.toString()
+        val workOrderNumber = workOrderBuilder.toString()
+
+        if (employeeNumber.isBlank() || workOrderNumber.isBlank()) {
+            Toast.makeText(
+                this,
+                getString(R.string.toast_enter_employee_and_work_order),
+                Toast.LENGTH_SHORT
+            ).show()
+            return
+        }
+
+        val message = if (clockIn) {
+            val workOrders = workAssignments.getOrPut(employeeNumber) { mutableSetOf() }
+            workOrders.add(workOrderNumber)
+            getString(R.string.toast_clock_in_wo, employeeNumber, workOrderNumber)
+        } else {
+            val workOrders = workAssignments[employeeNumber]
+            workOrders?.remove(workOrderNumber)
+            if (workOrders != null && workOrders.isEmpty()) {
+                workAssignments.remove(employeeNumber)
+            }
+            getString(R.string.toast_clock_out_wo, employeeNumber, workOrderNumber)
+        }
+
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+    }
+
+    companion object {
+        private val workAssignments = mutableMapOf<String, MutableSet<String>>()
     }
 }

--- a/app/src/main/res/layout/activity_issue_materials.xml
+++ b/app/src/main/res/layout/activity_issue_materials.xml
@@ -1,19 +1,250 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fillViewport="true">
 
-    <TextView
-        android:id="@+id/textIssueMaterials"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/issue_materials_screen"
-        android:textAppearance="@android:style/TextAppearance.Large"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:padding="24dp">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:id="@+id/textIssueTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:gravity="center"
+            android:text="@string/issue_materials_screen"
+            android:textAppearance="@android:style/TextAppearance.Large"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/textIssueActiveInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:gravity="center"
+            android:text="@string/issue_materials_active_employee"
+            android:textAppearance="@android:style/TextAppearance.Medium"
+            android:textStyle="bold" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/labelIssueEmployee"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/issue_materials_employee_label"
+                android:textAppearance="@android:style/TextAppearance.Small"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/textIssueEmployeeValue"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@android:drawable/editbox_background"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center"
+                android:padding="16dp"
+                android:text="@string/default_input_placeholder"
+                android:textAppearance="@android:style/TextAppearance.Large"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="24dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/labelMaterial"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/issue_materials_material_label"
+                android:textAppearance="@android:style/TextAppearance.Small"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/textMaterialValue"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@android:drawable/editbox_background"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center"
+                android:padding="16dp"
+                android:text="@string/default_input_placeholder"
+                android:textAppearance="@android:style/TextAppearance.Large"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="24dp"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:gravity="center"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/buttonKey1"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="1"
+                    android:text="1"
+                    android:textSize="20sp" />
+
+                <Button
+                    android:id="@+id/buttonKey2"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="1"
+                    android:text="2"
+                    android:textSize="20sp" />
+
+                <Button
+                    android:id="@+id/buttonKey3"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_weight="1"
+                    android:text="3"
+                    android:textSize="20sp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:gravity="center"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/buttonKey4"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="1"
+                    android:text="4"
+                    android:textSize="20sp" />
+
+                <Button
+                    android:id="@+id/buttonKey5"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="1"
+                    android:text="5"
+                    android:textSize="20sp" />
+
+                <Button
+                    android:id="@+id/buttonKey6"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_weight="1"
+                    android:text="6"
+                    android:textSize="20sp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:gravity="center"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/buttonKey7"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="1"
+                    android:text="7"
+                    android:textSize="20sp" />
+
+                <Button
+                    android:id="@+id/buttonKey8"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="1"
+                    android:text="8"
+                    android:textSize="20sp" />
+
+                <Button
+                    android:id="@+id/buttonKey9"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_weight="1"
+                    android:text="9"
+                    android:textSize="20sp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/buttonClear"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="1"
+                    android:text="@string/clear"
+                    android:textSize="18sp" />
+
+                <Button
+                    android:id="@+id/buttonKey0"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="1"
+                    android:text="0"
+                    android:textSize="20sp" />
+
+                <Button
+                    android:id="@+id/buttonEnter"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_weight="1"
+                    android:text="@string/enter"
+                    android:textSize="18sp" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/buttonIssueMaterial"
+            android:layout_width="match_parent"
+            android:layout_height="72dp"
+            android:text="@string/button_issue_material"
+            android:textAllCaps="false"
+            android:textSize="20sp" />
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/activity_work_orders.xml
+++ b/app/src/main/res/layout/activity_work_orders.xml
@@ -1,19 +1,259 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fillViewport="true">
 
-    <TextView
-        android:id="@+id/textWorkOrders"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/work_orders_screen"
-        android:textAppearance="@android:style/TextAppearance.Large"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:padding="24dp">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:id="@+id/textWorkOrdersTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:gravity="center"
+            android:text="@string/work_orders_screen"
+            android:textAppearance="@android:style/TextAppearance.Large"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/textActiveInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:gravity="center"
+            android:text="@string/work_orders_active_employee"
+            android:textAppearance="@android:style/TextAppearance.Medium"
+            android:textStyle="bold" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/labelEmployee"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/work_orders_employee_label"
+                android:textAppearance="@android:style/TextAppearance.Small"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/textEmployeeValue"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@android:drawable/editbox_background"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center"
+                android:padding="16dp"
+                android:text="@string/default_input_placeholder"
+                android:textAppearance="@android:style/TextAppearance.Large"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="24dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/labelWorkOrder"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/work_orders_work_order_label"
+                android:textAppearance="@android:style/TextAppearance.Small"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/textWorkOrderValue"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@android:drawable/editbox_background"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center"
+                android:padding="16dp"
+                android:text="@string/default_input_placeholder"
+                android:textAppearance="@android:style/TextAppearance.Large"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="24dp"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:gravity="center"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/buttonKey1"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="1"
+                    android:text="1"
+                    android:textSize="20sp" />
+
+                <Button
+                    android:id="@+id/buttonKey2"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="1"
+                    android:text="2"
+                    android:textSize="20sp" />
+
+                <Button
+                    android:id="@+id/buttonKey3"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_weight="1"
+                    android:text="3"
+                    android:textSize="20sp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:gravity="center"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/buttonKey4"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="1"
+                    android:text="4"
+                    android:textSize="20sp" />
+
+                <Button
+                    android:id="@+id/buttonKey5"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="1"
+                    android:text="5"
+                    android:textSize="20sp" />
+
+                <Button
+                    android:id="@+id/buttonKey6"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_weight="1"
+                    android:text="6"
+                    android:textSize="20sp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:gravity="center"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/buttonKey7"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="1"
+                    android:text="7"
+                    android:textSize="20sp" />
+
+                <Button
+                    android:id="@+id/buttonKey8"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="1"
+                    android:text="8"
+                    android:textSize="20sp" />
+
+                <Button
+                    android:id="@+id/buttonKey9"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_weight="1"
+                    android:text="9"
+                    android:textSize="20sp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/buttonClear"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="1"
+                    android:text="@string/clear"
+                    android:textSize="18sp" />
+
+                <Button
+                    android:id="@+id/buttonKey0"
+                    style="@style/Widget.AppCompat.Button.Borderless"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="1"
+                    android:text="0"
+                    android:textSize="20sp" />
+
+                <Button
+                    android:id="@+id/buttonEnter"
+                    android:layout_width="0dp"
+                    android:layout_height="64dp"
+                    android:layout_weight="1"
+                    android:text="@string/enter"
+                    android:textSize="18sp" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/buttonClockInWo"
+            android:layout_width="match_parent"
+            android:layout_height="72dp"
+            android:layout_marginBottom="16dp"
+            android:text="@string/button_clock_in_wo"
+            android:textAllCaps="false"
+            android:textSize="20sp" />
+
+        <Button
+            android:id="@+id/buttonClockOutWo"
+            android:layout_width="match_parent"
+            android:layout_height="72dp"
+            android:text="@string/button_clock_out_wo"
+            android:textAllCaps="false"
+            android:textSize="20sp" />
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,21 @@
     <string name="toast_clock_in_success">Clock In Successful</string>
     <string name="toast_clock_out_success">Clock Out Successful</string>
     <string name="toast_enter_employee_number">Ingresa un número de empleado</string>
+    <string name="default_input_placeholder">--</string>
+    <string name="work_orders_active_employee">Ingresando número de empleado</string>
+    <string name="work_orders_active_work_order">Ingresando orden de trabajo</string>
+    <string name="work_orders_employee_label">Empleado</string>
+    <string name="work_orders_work_order_label">Orden de trabajo</string>
+    <string name="toast_enter_employee_and_work_order">Ingresa número de empleado y orden de trabajo</string>
+    <string name="toast_clock_in_wo">Employee %1$s Clocked In on WO %2$s</string>
+    <string name="toast_clock_out_wo">Employee %1$s Clocked Out from WO %2$s</string>
+    <string name="button_clock_in_wo">Clock In WO</string>
+    <string name="button_clock_out_wo">Clock Out WO</string>
+    <string name="issue_materials_active_employee">Ingresando número de empleado</string>
+    <string name="issue_materials_active_material">Ingresando código de material</string>
+    <string name="issue_materials_employee_label">Empleado</string>
+    <string name="issue_materials_material_label">Material</string>
+    <string name="toast_enter_employee_and_material">Ingresa número de empleado y código de material</string>
+    <string name="toast_issue_material">Employee %1$s issued Material %2$s</string>
+    <string name="button_issue_material">Issue Material</string>
 </resources>


### PR DESCRIPTION
## Summary
- Build new keypad-driven UI for work orders that captures employee and work order numbers and adds clock in/out actions backed by in-memory state tracking.
- Expand the issue materials screen to capture employee and material codes with the shared keypad and persist issued material records in memory.
- Add supporting layouts and string resources for field labels, instructions, and user feedback messages.

## Testing
- `./gradlew lint --console=plain` *(fails: Android SDK missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caba1ed5ac8331b180aff855cf988b