### PR TITLE
Add navigation and Compose clock screen state management

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.navigation.compose)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/terminal/TerminalApp.kt
+++ b/app/src/main/java/com/example/terminal/TerminalApp.kt
@@ -2,64 +2,80 @@ package com.example.terminal
 
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import com.example.terminal.ui.theme.TerminalTheme
 
 @Composable
 fun TerminalApp() {
-    val context = LocalContext.current
-    val inputState = remember { mutableStateOf("") }
+    val navController = rememberNavController()
+    val loginStates = rememberSaveable(saver = LoginStateSaver) { mutableStateMapOf<Int, Boolean>() }
 
     Surface(
         modifier = Modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background
     ) {
-        Row(modifier = Modifier.fillMaxSize()) {
-            LeftPanel(
-                modifier = Modifier
-                    .weight(0.6f)
-                    .fillMaxHeight()
-            )
-            KeypadPanel(
-                modifier = Modifier
-                    .weight(0.4f)
-                    .fillMaxHeight(),
-                inputValue = inputState.value,
-                onNumberClick = { digit -> inputState.value += digit },
-                onClear = { inputState.value = "" },
-                onEnter = {
-                    Toast.makeText(context, inputState.value, Toast.LENGTH_SHORT).show()
-                    inputState.value = ""
-                }
-            )
+        NavHost(
+            navController = navController,
+            startDestination = "menu",
+            modifier = Modifier.fillMaxSize()
+        ) {
+            composable("menu") {
+                LeftPanel(
+                    navController = navController,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+            composable("clock") {
+                ClockScreen(
+                    loginStates = loginStates,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+            composable("workorders") {
+                WorkOrdersScreen(modifier = Modifier.fillMaxSize())
+            }
+            composable("materials") {
+                IssueMaterialsScreen(modifier = Modifier.fillMaxSize())
+            }
         }
     }
 }
 
 @Composable
-private fun LeftPanel(modifier: Modifier = Modifier) {
+private fun LeftPanel(
+    navController: NavHostController,
+    modifier: Modifier = Modifier
+) {
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -73,18 +89,18 @@ private fun LeftPanel(modifier: Modifier = Modifier) {
             modifier = Modifier.align(Alignment.Start)
         )
         Spacer(modifier = Modifier.height(32.dp))
-        MenuButton(text = "Clock In/Out")
+        MenuButton(text = "Clock In/Out", onClick = { navController.navigate("clock") })
         Spacer(modifier = Modifier.height(16.dp))
-        MenuButton(text = "Work Orders")
+        MenuButton(text = "Work Orders", onClick = { navController.navigate("workorders") })
         Spacer(modifier = Modifier.height(16.dp))
-        MenuButton(text = "Issue Materials")
+        MenuButton(text = "Issue Materials", onClick = { navController.navigate("materials") })
     }
 }
 
 @Composable
-private fun MenuButton(text: String) {
+private fun MenuButton(text: String, onClick: () -> Unit) {
     Button(
-        onClick = { /* TODO */ },
+        onClick = onClick,
         modifier = Modifier
             .fillMaxWidth()
             .height(72.dp)
@@ -168,6 +184,85 @@ private fun RowScope.KeypadButton(
         )
     }
 }
+
+@Composable
+private fun ClockScreen(
+    loginStates: SnapshotStateMap<Int, Boolean>,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    var inputValue by rememberSaveable { mutableStateOf("") }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Top,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Clock In/Out",
+            style = MaterialTheme.typography.headlineSmall,
+            modifier = Modifier.align(Alignment.Start)
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        KeypadPanel(
+            modifier = Modifier.fillMaxWidth(),
+            inputValue = inputValue,
+            onNumberClick = { digit -> inputValue += digit },
+            onClear = { inputValue = "" },
+            onEnter = {
+                val employeeNumber = inputValue.toIntOrNull()
+                if (employeeNumber == null) {
+                    Toast.makeText(context, "Ingrese un número de empleado", Toast.LENGTH_SHORT).show()
+                } else {
+                    val isLoggedIn = loginStates[employeeNumber] == true
+                    if (isLoggedIn) {
+                        Toast.makeText(context, "Clock Out Successful", Toast.LENGTH_SHORT).show()
+                        loginStates.remove(employeeNumber)
+                    } else {
+                        Toast.makeText(context, "Clock In Successful", Toast.LENGTH_SHORT).show()
+                        loginStates[employeeNumber] = true
+                    }
+                }
+                inputValue = ""
+            }
+        )
+    }
+}
+
+@Composable
+private fun WorkOrdersScreen(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "Pantalla Work Orders",
+            style = MaterialTheme.typography.headlineSmall
+        )
+    }
+}
+
+@Composable
+private fun IssueMaterialsScreen(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "Pantalla Issue Materials",
+            style = MaterialTheme.typography.headlineSmall
+        )
+    }
+}
+
+private val LoginStateSaver: Saver<SnapshotStateMap<Int, Boolean>, Map<Int, Boolean>> = Saver(
+    save = { stateMap -> stateMap.toMap() },
+    restore = { restoredMap ->
+        mutableStateMapOf<Int, Boolean>().apply { putAll(restoredMap) }
+    }
+)
 
 @Preview(showBackground = true, widthDp = 900, heightDp = 450)
 @Composable

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ activityCompose = "1.8.0"
 composeBom = "2024.09.00"
 appcompat = "1.6.1"
 constraintlayout = "2.1.4"
+navigationCompose = "2.8.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -28,6 +29,7 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add Navigation Compose dependency to the project
- wire a NavHost with menu, clock, work orders, and materials routes in TerminalApp
- reuse the keypad for the Clock screen while tracking login state and showing success toasts
- add placeholder Work Orders and Issue Materials screens

## Testing
- ./gradlew lint *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cac3276e848331a6ad46d66f220b29