### PR TITLE
Refactor numeric keypad buttons to use image background

### DIFF
--- a/app/src/main/java/com/example/terminal/TerminalApp.kt
+++ b/app/src/main/java/com/example/terminal/TerminalApp.kt
@@ -1,6 +1,8 @@
 package com.example.terminal
 
 import android.widget.Toast
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -28,10 +30,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.example.terminal.ui.theme.TerminalTheme
 import java.util.ArrayList
 
@@ -486,15 +492,24 @@ private fun RowScope.KeypadButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Button(
-        onClick = onClick,
+    Box(
         modifier = modifier
             .weight(1f)
             .height(72.dp)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center
     ) {
+        Image(
+            painter = painterResource(id = R.drawable.button),
+            contentDescription = null,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.FillBounds
+        )
         Text(
             text = label,
-            style = MaterialTheme.typography.titleLarge
+            color = Color.White,
+            fontSize = 20.sp,
+            textAlign = TextAlign.Center
         )
     }
 }


### PR DESCRIPTION
## Summary
- update the numeric keypad buttons to use a custom drawable-backed Box instead of Material buttons
- render the button.png asset as the background image and overlay the key labels in white text
- preserve existing keypad layout and callbacks while keeping other buttons on the screen unchanged

## Testing
- ./gradlew :app:assembleDebug *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cad1fd0dd88331bf7f977f0c615e66