### PR TITLE
Add missing size import for keypad button

### DIFF
--- a/app/src/main/java/com/example/terminal/TerminalApp.kt
+++ b/app/src/main/java/com/example/terminal/TerminalApp.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme


### PR DESCRIPTION
## Summary
- add the missing Modifier.size import so the keypad button image compiles

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cad3cdae3883318ead957be524eada