### PR TITLE
Import aspectRatio extension

### DIFF
--- a/app/src/main/java/com/example/terminal/TerminalApp.kt
+++ b/app/src/main/java/com/example/terminal/TerminalApp.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth


### PR DESCRIPTION
## Summary
- add the missing aspectRatio import so the keypad button modifier compiles

## Testing
- `./gradlew assembleDebug` *(fails: Android SDK not configured in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cad5fa1e8c83319d97f78db3d736e8