### PR TITLE
Adjust keypad layout

### DIFF
--- a/app/src/main/java/com/example/terminal/TerminalApp.kt
+++ b/app/src/main/java/com/example/terminal/TerminalApp.kt
@@ -475,7 +475,9 @@ private fun NumericKeypad(
 
         LazyVerticalGrid(
             columns = GridCells.Fixed(3),
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
             horizontalArrangement = Arrangement.SpaceEvenly,
             verticalArrangement = Arrangement.SpaceEvenly,
             userScrollEnabled = false
@@ -508,12 +510,12 @@ private fun KeypadButton(
             painter = painterResource(id = R.drawable.button),
             contentDescription = null,
             modifier = Modifier.fillMaxSize(),
-            contentScale = ContentScale.FillBounds
+            contentScale = ContentScale.Fit
         )
         Text(
             text = label,
             color = Color.Black,
-            fontSize = 24.sp,
+            fontSize = 26.sp,
             textAlign = TextAlign.Center
         )
     }


### PR DESCRIPTION
## Summary
- expand the numeric keypad grid to use full available size with padding
- ensure keypad buttons maintain square shape while centering the background image
- increase keypad label visibility with larger font size

## Testing
- `./gradlew :app:lint` *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cad6cfef208331b4887605eb8d4d3a