### PR TITLE
Refactor keypad layout

### DIFF
--- a/app/src/main/java/com/example/terminal/TerminalApp.kt
+++ b/app/src/main/java/com/example/terminal/TerminalApp.kt
@@ -477,9 +477,9 @@ private fun NumericKeypad(
             columns = GridCells.Fixed(3),
             modifier = Modifier
                 .fillMaxSize()
-                .padding(16.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly,
-            verticalArrangement = Arrangement.SpaceEvenly,
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp),
+            horizontalArrangement = Arrangement.spacedBy(24.dp),
             userScrollEnabled = false
         ) {
             items(keypadItems, key = { it.first }) { (label, action) ->
@@ -500,9 +500,8 @@ private fun KeypadButton(
 ) {
     Box(
         modifier = modifier
-            .fillMaxWidth()
             .aspectRatio(1f)
-            .padding(8.dp)
+            .fillMaxSize(fraction = 0.9f)
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
@@ -515,7 +514,7 @@ private fun KeypadButton(
         Text(
             text = label,
             color = Color.Black,
-            fontSize = 26.sp,
+            fontSize = 28.sp,
             textAlign = TextAlign.Center
         )
     }


### PR DESCRIPTION
## Summary
- expand the keypad grid to use larger spacing and padding while filling the available panel height
- adjust keypad buttons to scale within their grid cells while keeping a square aspect ratio
- increase keypad label size for improved readability

## Testing
- ./gradlew lint *(fails: Android SDK not configured in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cad92985088331a246229c436b092a