### PR TITLE
Adjust numpad layout sizing

### DIFF
--- a/app/src/main/res/layout/activity_clock_in_out.xml
+++ b/app/src/main/res/layout/activity_clock_in_out.xml
@@ -41,156 +41,157 @@
             android:textAppearance="@android:style/TextAppearance.Large"
             android:textStyle="bold" />
 
-        <LinearLayout
+        <GridLayout
+            android:id="@+id/numpadGrid"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:orientation="vertical">
+            android:alignmentMode="alignMargins"
+            android:columnCount="3"
+            android:columnOrderPreserved="false"
+            android:useDefaultMargins="true">
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="12dp"
-                android:gravity="center"
-                android:orientation="horizontal">
+            <Button
+                android:id="@+id/buttonKey1"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="1"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey1"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="1"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonKey2"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="2"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey2"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="2"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonKey3"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="3"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey3"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_weight="1"
-                    android:text="3"
-                    android:textSize="20sp" />
-            </LinearLayout>
+            <Button
+                android:id="@+id/buttonKey4"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="4"
+                android:textSize="24sp" />
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="12dp"
-                android:gravity="center"
-                android:orientation="horizontal">
+            <Button
+                android:id="@+id/buttonKey5"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="5"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey4"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="4"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonKey6"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="6"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey5"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="5"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonKey7"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="7"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey6"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_weight="1"
-                    android:text="6"
-                    android:textSize="20sp" />
-            </LinearLayout>
+            <Button
+                android:id="@+id/buttonKey8"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="8"
+                android:textSize="24sp" />
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="12dp"
-                android:gravity="center"
-                android:orientation="horizontal">
+            <Button
+                android:id="@+id/buttonKey9"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="9"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey7"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="7"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonClear"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="@string/clear"
+                android:textSize="20sp" />
 
-                <Button
-                    android:id="@+id/buttonKey8"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="8"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonKey0"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="0"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey9"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_weight="1"
-                    android:text="9"
-                    android:textSize="20sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:orientation="horizontal">
-
-                <Button
-                    android:id="@+id/buttonClear"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="@string/clear"
-                    android:textSize="18sp" />
-
-                <Button
-                    android:id="@+id/buttonKey0"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="0"
-                    android:textSize="20sp" />
-
-                <Button
-                    android:id="@+id/buttonEnter"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_weight="1"
-                    android:text="@string/enter"
-                    android:textSize="18sp" />
-            </LinearLayout>
-        </LinearLayout>
+            <Button
+                android:id="@+id/buttonEnter"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="@string/enter"
+                android:textSize="20sp" />
+        </GridLayout>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_issue_materials.xml
+++ b/app/src/main/res/layout/activity_issue_materials.xml
@@ -87,157 +87,158 @@
                 android:textStyle="bold" />
         </LinearLayout>
 
-        <LinearLayout
+        <GridLayout
+            android:id="@+id/numpadGrid"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="24dp"
-            android:orientation="vertical">
+            android:alignmentMode="alignMargins"
+            android:columnCount="3"
+            android:columnOrderPreserved="false"
+            android:useDefaultMargins="true">
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="12dp"
-                android:gravity="center"
-                android:orientation="horizontal">
+            <Button
+                android:id="@+id/buttonKey1"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="1"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey1"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="1"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonKey2"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="2"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey2"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="2"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonKey3"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="3"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey3"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_weight="1"
-                    android:text="3"
-                    android:textSize="20sp" />
-            </LinearLayout>
+            <Button
+                android:id="@+id/buttonKey4"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="4"
+                android:textSize="24sp" />
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="12dp"
-                android:gravity="center"
-                android:orientation="horizontal">
+            <Button
+                android:id="@+id/buttonKey5"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="5"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey4"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="4"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonKey6"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="6"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey5"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="5"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonKey7"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="7"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey6"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_weight="1"
-                    android:text="6"
-                    android:textSize="20sp" />
-            </LinearLayout>
+            <Button
+                android:id="@+id/buttonKey8"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="8"
+                android:textSize="24sp" />
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="12dp"
-                android:gravity="center"
-                android:orientation="horizontal">
+            <Button
+                android:id="@+id/buttonKey9"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="9"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey7"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="7"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonClear"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="@string/clear"
+                android:textSize="20sp" />
 
-                <Button
-                    android:id="@+id/buttonKey8"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="8"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonKey0"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="0"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey9"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_weight="1"
-                    android:text="9"
-                    android:textSize="20sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:orientation="horizontal">
-
-                <Button
-                    android:id="@+id/buttonClear"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="@string/clear"
-                    android:textSize="18sp" />
-
-                <Button
-                    android:id="@+id/buttonKey0"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="0"
-                    android:textSize="20sp" />
-
-                <Button
-                    android:id="@+id/buttonEnter"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_weight="1"
-                    android:text="@string/enter"
-                    android:textSize="18sp" />
-            </LinearLayout>
-        </LinearLayout>
+            <Button
+                android:id="@+id/buttonEnter"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="@string/enter"
+                android:textSize="20sp" />
+        </GridLayout>
 
         <Button
             android:id="@+id/buttonIssueMaterial"

--- a/app/src/main/res/layout/activity_work_orders.xml
+++ b/app/src/main/res/layout/activity_work_orders.xml
@@ -87,157 +87,158 @@
                 android:textStyle="bold" />
         </LinearLayout>
 
-        <LinearLayout
+        <GridLayout
+            android:id="@+id/numpadGrid"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="24dp"
-            android:orientation="vertical">
+            android:alignmentMode="alignMargins"
+            android:columnCount="3"
+            android:columnOrderPreserved="false"
+            android:useDefaultMargins="true">
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="12dp"
-                android:gravity="center"
-                android:orientation="horizontal">
+            <Button
+                android:id="@+id/buttonKey1"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="1"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey1"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="1"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonKey2"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="2"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey2"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="2"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonKey3"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="3"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey3"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_weight="1"
-                    android:text="3"
-                    android:textSize="20sp" />
-            </LinearLayout>
+            <Button
+                android:id="@+id/buttonKey4"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="4"
+                android:textSize="24sp" />
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="12dp"
-                android:gravity="center"
-                android:orientation="horizontal">
+            <Button
+                android:id="@+id/buttonKey5"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="5"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey4"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="4"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonKey6"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="6"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey5"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="5"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonKey7"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="7"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey6"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_weight="1"
-                    android:text="6"
-                    android:textSize="20sp" />
-            </LinearLayout>
+            <Button
+                android:id="@+id/buttonKey8"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="8"
+                android:textSize="24sp" />
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="12dp"
-                android:gravity="center"
-                android:orientation="horizontal">
+            <Button
+                android:id="@+id/buttonKey9"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="9"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey7"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="7"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonClear"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="@string/clear"
+                android:textSize="20sp" />
 
-                <Button
-                    android:id="@+id/buttonKey8"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="8"
-                    android:textSize="20sp" />
+            <Button
+                android:id="@+id/buttonKey0"
+                style="@style/Widget.AppCompat.Button.Borderless"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="0"
+                android:textSize="24sp" />
 
-                <Button
-                    android:id="@+id/buttonKey9"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_weight="1"
-                    android:text="9"
-                    android:textSize="20sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:orientation="horizontal">
-
-                <Button
-                    android:id="@+id/buttonClear"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="@string/clear"
-                    android:textSize="18sp" />
-
-                <Button
-                    android:id="@+id/buttonKey0"
-                    style="@style/Widget.AppCompat.Button.Borderless"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="1"
-                    android:text="0"
-                    android:textSize="20sp" />
-
-                <Button
-                    android:id="@+id/buttonEnter"
-                    android:layout_width="0dp"
-                    android:layout_height="64dp"
-                    android:layout_weight="1"
-                    android:text="@string/enter"
-                    android:textSize="18sp" />
-            </LinearLayout>
-        </LinearLayout>
+            <Button
+                android:id="@+id/buttonEnter"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_columnWeight="1"
+                android:layout_rowWeight="1"
+                android:minHeight="96dp"
+                android:minWidth="0dp"
+                android:text="@string/enter"
+                android:textSize="20sp" />
+        </GridLayout>
 
         <Button
             android:id="@+id/buttonClockInWo"


### PR DESCRIPTION
## Summary
- switch the numpad sections in the clock, issue, and work order screens to a single GridLayout so the buttons expand uniformly and cover more width

## Testing
- ./gradlew lint *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cae2562be48331b8f093efb72eaed6