### PR TITLE
Style TabRow to match modern design

### DIFF
--- a/app/src/main/java/com/example/terminal/TerminalApp.kt
+++ b/app/src/main/java/com/example/terminal/TerminalApp.kt
@@ -22,7 +22,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
+import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.tabIndicatorOffset
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
@@ -37,6 +39,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -62,12 +65,35 @@ fun TerminalApp() {
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
             val selectedIndex = tabs.indexOf(selectedTab)
-            TabRow(selectedTabIndex = selectedIndex) {
+            TabRow(
+                selectedTabIndex = selectedIndex,
+                containerColor = Color(0xFFF5F5F5),
+                indicator = { tabPositions ->
+                    TabRowDefaults.Indicator(
+                        modifier = Modifier.tabIndicatorOffset(tabPositions[selectedIndex]),
+                        height = 3.dp,
+                        color = Color(0xFF2196F3)
+                    )
+                }
+            ) {
                 tabs.forEachIndexed { index, tab ->
+                    val isSelected = index == selectedIndex
                     Tab(
-                        selected = index == selectedIndex,
+                        selected = isSelected,
                         onClick = { selectedTab = tab },
-                        text = { Text(tab.title) }
+                        text = {
+                            Text(
+                                text = tab.title.uppercase(),
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                                fontSize = 16.sp,
+                                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                                color = if (isSelected) Color(0xFF000000) else Color(0xFF888888)
+                            )
+                        },
+                        colors = TabRowDefaults.tabColors(
+                            selectedContentColor = Color(0xFF000000),
+                            unselectedContentColor = Color(0xFF888888)
+                        )
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- style the Compose TabRow to use a light background and bold, uppercase text
- add a thicker blue indicator and adjust tab colors for selected and unselected states

## Testing
- ./gradlew test *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cae40a64548331b04908a79f4dc71d