### PR TITLE
Fix Tab colors usage for Material3

### DIFF
--- a/app/src/main/java/com/example/terminal/TerminalApp.kt
+++ b/app/src/main/java/com/example/terminal/TerminalApp.kt
@@ -104,10 +104,8 @@ fun TerminalApp() {
                                 color = if (isSelected) Color(0xFF000000) else Color(0xFF888888)
                             )
                         },
-                        colors = TabRowDefaults.tabColors(
-                            selectedContentColor = Color(0xFF000000),
-                            unselectedContentColor = Color(0xFF888888)
-                        )
+                        selectedContentColor = Color(0xFF000000),
+                        unselectedContentColor = Color(0xFF888888)
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- update the Tab composable call to use Material 3's selected/unselected content color parameters

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dad5c0b17c8331813d04918533908f