### PR TITLE
Set terminal background to #55575A

### DIFF
--- a/app/src/main/java/com/example/terminal/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/terminal/ui/theme/Theme.kt
@@ -9,18 +9,27 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(
     primary = Purple80,
     secondary = PurpleGrey80,
-    tertiary = Pink80
+    tertiary = Pink80,
+    background = Color(0xFF55575A),
+    surface = Color(0xFF55575A),
+    onBackground = Color(0xFFFFFFFF),
+    onSurface = Color(0xFFFFFFFF)
 )
 
 private val LightColorScheme = lightColorScheme(
     primary = Purple40,
     secondary = PurpleGrey40,
-    tertiary = Pink40
+    tertiary = Pink40,
+    background = Color(0xFF55575A),
+    surface = Color(0xFF55575A),
+    onBackground = Color(0xFFFFFFFF),
+    onSurface = Color(0xFFFFFFFF)
 
     /* Other default colors to override
     background = Color(0xFFFFFBFE),


### PR DESCRIPTION
## Summary
- update the light and dark Material 3 color schemes to use #55575A as the background and surface color
- adjust the on-background and on-surface colors to white so content stays legible on the new background

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc16b2cca883318e2a8681c6f09b0c