### PR TITLE
Apply dark terminal color scheme

### DIFF
--- a/app/src/main/java/com/example/terminal/TerminalApp.kt
+++ b/app/src/main/java/com/example/terminal/TerminalApp.kt
@@ -1,9 +1,6 @@
 package com.example.terminal
 
 import android.widget.Toast
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,19 +11,19 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -38,10 +35,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -70,23 +64,13 @@ fun TerminalApp() {
             val selectedIndex = tabs.indexOf(selectedTab)
             TabRow(
                 selectedTabIndex = selectedIndex,
-                containerColor = Color(0xFFF5F5F5),
+                containerColor = MaterialTheme.colorScheme.background,
                 indicator = { tabPositions ->
                     if (tabPositions.isNotEmpty()) {
-                        val currentTabPosition = tabPositions[selectedIndex]
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .wrapContentSize(Alignment.BottomStart)
-                        ) {
-                            Box(
-                                modifier = Modifier
-                                    .offset(x = currentTabPosition.left)
-                                    .width(currentTabPosition.right - currentTabPosition.left)
-                                    .height(3.dp)
-                                    .background(Color(0xFF2196F3))
-                            )
-                        }
+                        TabRowDefaults.Indicator(
+                            modifier = Modifier.tabIndicatorOffset(tabPositions[selectedIndex]),
+                            color = MaterialTheme.colorScheme.primary
+                        )
                     }
                 }
             ) {
@@ -101,11 +85,15 @@ fun TerminalApp() {
                                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
                                 fontSize = 16.sp,
                                 fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-                                color = if (isSelected) Color(0xFF000000) else Color(0xFF888888)
+                                color = if (isSelected) {
+                                    MaterialTheme.colorScheme.onSurface
+                                } else {
+                                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                                }
                             )
                         },
-                        selectedContentColor = Color(0xFF000000),
-                        unselectedContentColor = Color(0xFF888888)
+                        selectedContentColor = MaterialTheme.colorScheme.onSurface,
+                        unselectedContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
                     )
                 }
             }
@@ -158,7 +146,8 @@ private fun ClockTabContent(
         ) {
             Text(
                 text = "Clock In/Out",
-                style = MaterialTheme.typography.headlineSmall
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onSurface
             )
             Spacer(modifier = Modifier.height(24.dp))
             DisplayValue(
@@ -173,7 +162,8 @@ private fun ClockTabContent(
             Spacer(modifier = Modifier.height(16.dp))
             Text(
                 text = "Ingrese el número de empleado y presione Enter para clock in/out.",
-                style = MaterialTheme.typography.bodyLarge
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
             )
         }
 
@@ -236,7 +226,8 @@ private fun WorkOrdersTabContent(
         ) {
             Text(
                 text = "Work Orders",
-                style = MaterialTheme.typography.headlineSmall
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onSurface
             )
             Spacer(modifier = Modifier.height(24.dp))
             DisplayValue(label = "Employee", value = employeeNumber?.toString().orEmpty())
@@ -245,7 +236,8 @@ private fun WorkOrdersTabContent(
             Spacer(modifier = Modifier.height(16.dp))
             Text(
                 text = instructionText,
-                style = MaterialTheme.typography.bodyLarge
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
             )
             Spacer(modifier = Modifier.height(24.dp))
             Button(
@@ -273,9 +265,17 @@ private fun WorkOrdersTabContent(
                 },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(72.dp)
+                    .height(72.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                )
             ) {
-                Text(text = "Clock In WO", style = MaterialTheme.typography.titleLarge)
+                Text(
+                    text = "Clock In WO",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
             }
             Spacer(modifier = Modifier.height(16.dp))
             Button(
@@ -310,9 +310,17 @@ private fun WorkOrdersTabContent(
                 },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(72.dp)
+                    .height(72.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                )
             ) {
-                Text(text = "Clock Out WO", style = MaterialTheme.typography.titleLarge)
+                Text(
+                    text = "Clock Out WO",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
             }
         }
 
@@ -387,7 +395,8 @@ private fun IssueMaterialsTabContent(
         ) {
             Text(
                 text = "Issue Materials",
-                style = MaterialTheme.typography.headlineSmall
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onSurface
             )
             Spacer(modifier = Modifier.height(24.dp))
             DisplayValue(label = "Employee", value = employeeNumber?.toString().orEmpty())
@@ -396,7 +405,8 @@ private fun IssueMaterialsTabContent(
             Spacer(modifier = Modifier.height(16.dp))
             Text(
                 text = instructionText,
-                style = MaterialTheme.typography.bodyLarge
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
             )
             Spacer(modifier = Modifier.height(24.dp))
             Button(
@@ -426,9 +436,17 @@ private fun IssueMaterialsTabContent(
                 },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(72.dp)
+                    .height(72.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                )
             ) {
-                Text(text = "Issue Material", style = MaterialTheme.typography.titleLarge)
+                Text(
+                    text = "Issue Material",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
             }
         }
 
@@ -481,7 +499,8 @@ private fun DisplayValue(label: String, value: String) {
         text = "$label: ${value.ifEmpty { "--" }}",
         style = MaterialTheme.typography.titleLarge,
         modifier = Modifier.fillMaxWidth(),
-        textAlign = TextAlign.Start
+        textAlign = TextAlign.Start,
+        color = MaterialTheme.colorScheme.onSurface
     )
 }
 
@@ -536,25 +555,27 @@ private fun KeypadButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Box(
+    Surface(
         modifier = modifier
             .aspectRatio(1f)
-            .fillMaxSize(fraction = 0.9f)
-            .clickable(onClick = onClick),
-        contentAlignment = Alignment.Center
+            .fillMaxSize(fraction = 0.9f),
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.primary,
+        contentColor = MaterialTheme.colorScheme.onPrimary,
+        shadowElevation = 4.dp,
+        onClick = onClick
     ) {
-        Image(
-            painter = painterResource(id = R.drawable.button),
-            contentDescription = null,
+        Box(
             modifier = Modifier.fillMaxSize(),
-            contentScale = ContentScale.Fit
-        )
-        Text(
-            text = label,
-            color = Color.Black,
-            fontSize = 28.sp,
-            textAlign = TextAlign.Center
-        )
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = label,
+                fontSize = 28.sp,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/example/terminal/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/terminal/ui/theme/Color.kt
@@ -2,10 +2,9 @@ package com.example.terminal.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
-
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+val TerminalBackground = Color(0xFF55575A)
+val TerminalSurface = Color(0xFF55575A)
+val TerminalPrimary = Color(0xFF76797C)
+val TerminalSecondary = Color(0xFF6B6D70)
+val TerminalTertiary = Color(0xFF8B8E92)
+val TerminalOnColor = Color(0xFFFFFFFF)

--- a/app/src/main/java/com/example/terminal/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/terminal/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package com.example.terminal.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -9,44 +8,39 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80,
-    background = Color(0xFF55575A),
-    surface = Color(0xFF55575A),
-    onBackground = Color(0xFFFFFFFF),
-    onSurface = Color(0xFFFFFFFF)
+    primary = TerminalPrimary,
+    onPrimary = TerminalOnColor,
+    secondary = TerminalSecondary,
+    onSecondary = TerminalOnColor,
+    tertiary = TerminalTertiary,
+    onTertiary = TerminalOnColor,
+    background = TerminalBackground,
+    onBackground = TerminalOnColor,
+    surface = TerminalSurface,
+    onSurface = TerminalOnColor
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40,
-    background = Color(0xFF55575A),
-    surface = Color(0xFF55575A),
-    onBackground = Color(0xFFFFFFFF),
-    onSurface = Color(0xFFFFFFFF)
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+    primary = TerminalPrimary,
+    onPrimary = TerminalOnColor,
+    secondary = TerminalSecondary,
+    onSecondary = TerminalOnColor,
+    tertiary = TerminalTertiary,
+    onTertiary = TerminalOnColor,
+    background = TerminalBackground,
+    onBackground = TerminalOnColor,
+    surface = TerminalSurface,
+    onSurface = TerminalOnColor
 )
 
 @Composable
 fun TerminalTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
+    dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {

--- a/app/src/main/res/drawable/input_field_background.xml
+++ b/app/src/main/res/drawable/input_field_background.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#26FFFFFF" />
+    <corners android:radius="12dp" />
+    <stroke
+        android:width="1dp"
+        android:color="#80FFFFFF" />
+    <padding
+        android:left="12dp"
+        android:top="12dp"
+        android:right="12dp"
+        android:bottom="12dp" />
+</shape>
+

--- a/app/src/main/res/drawable/rounded_button_background.xml
+++ b/app/src/main/res/drawable/rounded_button_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/terminal_primary" />
+    <corners android:radius="12dp" />
+</shape>
+

--- a/app/src/main/res/layout/activity_clock_in_out.xml
+++ b/app/src/main/res/layout/activity_clock_in_out.xml
@@ -2,11 +2,13 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/terminal_background"
     android:fillViewport="true">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@color/terminal_background"
         android:gravity="center_horizontal"
         android:orientation="vertical"
         android:padding="24dp">
@@ -18,17 +20,20 @@
             android:layout_marginBottom="24dp"
             android:gravity="center"
             android:text="@string/clock_in_out_screen"
-            android:textAppearance="@android:style/TextAppearance.Large" />
+            android:textAppearance="@android:style/TextAppearance.Large"
+            android:textColor="@color/terminal_on_background" />
 
         <EditText
             android:id="@+id/editEmployeeInput"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
-            android:background="@android:drawable/editbox_background"
+            android:background="@drawable/input_field_background"
             android:focusable="false"
             android:inputType="number"
             android:padding="12dp"
+            android:textColor="@color/terminal_on_background"
+            android:textColorHint="@color/terminal_on_background"
             android:textSize="18sp" />
 
         <TextView
@@ -39,7 +44,9 @@
             android:padding="16dp"
             android:text="@string/clock_in_out_display_placeholder"
             android:textAppearance="@android:style/TextAppearance.Large"
-            android:textStyle="bold" />
+            android:textColor="@color/terminal_on_background"
+            android:textStyle="bold"
+            android:background="@drawable/input_field_background" />
 
         <GridLayout
             android:id="@+id/numpadGrid"
@@ -61,6 +68,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="1"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -73,6 +81,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="2"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -85,6 +94,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="3"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -97,6 +107,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="4"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -109,6 +120,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="5"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -121,6 +133,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="6"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -133,6 +146,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="7"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -145,6 +159,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="8"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -157,6 +172,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="9"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -168,6 +184,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="@string/clear"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="20sp" />
 
             <Button
@@ -180,6 +197,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="0"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -191,6 +209,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="@string/enter"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="20sp" />
         </GridLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/activity_issue_materials.xml
+++ b/app/src/main/res/layout/activity_issue_materials.xml
@@ -2,11 +2,13 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/terminal_background"
     android:fillViewport="true">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@color/terminal_background"
         android:gravity="center_horizontal"
         android:orientation="vertical"
         android:padding="24dp">
@@ -19,6 +21,7 @@
             android:gravity="center"
             android:text="@string/issue_materials_screen"
             android:textAppearance="@android:style/TextAppearance.Large"
+            android:textColor="@color/terminal_on_background"
             android:textStyle="bold" />
 
         <TextView
@@ -29,6 +32,7 @@
             android:gravity="center"
             android:text="@string/issue_materials_active_employee"
             android:textAppearance="@android:style/TextAppearance.Medium"
+            android:textColor="@color/terminal_on_background"
             android:textStyle="bold" />
 
         <LinearLayout
@@ -43,19 +47,21 @@
                 android:layout_height="wrap_content"
                 android:text="@string/issue_materials_employee_label"
                 android:textAppearance="@android:style/TextAppearance.Small"
+                android:textColor="@color/terminal_on_background"
                 android:textStyle="bold" />
 
             <TextView
                 android:id="@+id/textIssueEmployeeValue"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@android:drawable/editbox_background"
+                android:background="@drawable/input_field_background"
                 android:clickable="true"
                 android:focusable="true"
                 android:gravity="center"
                 android:padding="16dp"
                 android:text="@string/default_input_placeholder"
                 android:textAppearance="@android:style/TextAppearance.Large"
+                android:textColor="@color/terminal_on_background"
                 android:textStyle="bold" />
         </LinearLayout>
 
@@ -71,19 +77,21 @@
                 android:layout_height="wrap_content"
                 android:text="@string/issue_materials_material_label"
                 android:textAppearance="@android:style/TextAppearance.Small"
+                android:textColor="@color/terminal_on_background"
                 android:textStyle="bold" />
 
             <TextView
                 android:id="@+id/textMaterialValue"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@android:drawable/editbox_background"
+                android:background="@drawable/input_field_background"
                 android:clickable="true"
                 android:focusable="true"
                 android:gravity="center"
                 android:padding="16dp"
                 android:text="@string/default_input_placeholder"
                 android:textAppearance="@android:style/TextAppearance.Large"
+                android:textColor="@color/terminal_on_background"
                 android:textStyle="bold" />
         </LinearLayout>
 
@@ -107,6 +115,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="1"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -119,6 +128,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="2"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -131,6 +141,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="3"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -143,6 +154,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="4"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -155,6 +167,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="5"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -167,6 +180,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="6"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -179,6 +193,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="7"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -191,6 +206,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="8"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -203,6 +219,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="9"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -214,6 +231,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="@string/clear"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="20sp" />
 
             <Button
@@ -226,6 +244,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="0"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -237,6 +256,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="@string/enter"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="20sp" />
         </GridLayout>
 
@@ -244,8 +264,10 @@
             android:id="@+id/buttonIssueMaterial"
             android:layout_width="match_parent"
             android:layout_height="72dp"
+            android:background="@drawable/rounded_button_background"
             android:text="@string/button_issue_material"
             android:textAllCaps="false"
+            android:textColor="@color/terminal_on_background"
             android:textSize="20sp" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/terminal_background"
     android:orientation="horizontal">
 
     <LinearLayout
@@ -9,7 +10,7 @@
         android:layout_width="0dp"
         android:layout_height="match_parent"
         android:layout_weight="1"
-        android:background="@android:color/darker_gray"
+        android:background="@color/terminal_background"
         android:gravity="center_horizontal"
         android:orientation="vertical"
         android:padding="16dp"
@@ -21,7 +22,9 @@
             android:layout_height="0dp"
             android:layout_marginBottom="16dp"
             android:layout_weight="1"
-            android:text="@string/clock_in_out" />
+            android:background="@drawable/rounded_button_background"
+            android:text="@string/clock_in_out"
+            android:textColor="@color/terminal_on_background" />
 
         <Button
             android:id="@+id/buttonWorkOrders"
@@ -29,20 +32,25 @@
             android:layout_height="0dp"
             android:layout_marginBottom="16dp"
             android:layout_weight="1"
-            android:text="@string/work_orders" />
+            android:background="@drawable/rounded_button_background"
+            android:text="@string/work_orders"
+            android:textColor="@color/terminal_on_background" />
 
         <Button
             android:id="@+id/buttonIssueMaterials"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:text="@string/issue_materials" />
+            android:background="@drawable/rounded_button_background"
+            android:text="@string/issue_materials"
+            android:textColor="@color/terminal_on_background" />
     </LinearLayout>
 
     <FrameLayout
         android:layout_width="0dp"
         android:layout_height="match_parent"
         android:layout_weight="2"
+        android:background="@color/terminal_background"
         android:foregroundGravity="center"
         android:padding="16dp">
 
@@ -51,6 +59,7 @@
             android:layout_height="wrap_content"
             android:gravity="center"
             android:text="@string/main_menu_placeholder"
-            android:textAppearance="@android:style/TextAppearance.Large" />
+            android:textAppearance="@android:style/TextAppearance.Large"
+            android:textColor="@color/terminal_on_background" />
     </FrameLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_work_orders.xml
+++ b/app/src/main/res/layout/activity_work_orders.xml
@@ -2,11 +2,13 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/terminal_background"
     android:fillViewport="true">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@color/terminal_background"
         android:gravity="center_horizontal"
         android:orientation="vertical"
         android:padding="24dp">
@@ -19,6 +21,7 @@
             android:gravity="center"
             android:text="@string/work_orders_screen"
             android:textAppearance="@android:style/TextAppearance.Large"
+            android:textColor="@color/terminal_on_background"
             android:textStyle="bold" />
 
         <TextView
@@ -29,6 +32,7 @@
             android:gravity="center"
             android:text="@string/work_orders_active_employee"
             android:textAppearance="@android:style/TextAppearance.Medium"
+            android:textColor="@color/terminal_on_background"
             android:textStyle="bold" />
 
         <LinearLayout
@@ -43,19 +47,21 @@
                 android:layout_height="wrap_content"
                 android:text="@string/work_orders_employee_label"
                 android:textAppearance="@android:style/TextAppearance.Small"
+                android:textColor="@color/terminal_on_background"
                 android:textStyle="bold" />
 
             <TextView
                 android:id="@+id/textEmployeeValue"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@android:drawable/editbox_background"
+                android:background="@drawable/input_field_background"
                 android:clickable="true"
                 android:focusable="true"
                 android:gravity="center"
                 android:padding="16dp"
                 android:text="@string/default_input_placeholder"
                 android:textAppearance="@android:style/TextAppearance.Large"
+                android:textColor="@color/terminal_on_background"
                 android:textStyle="bold" />
         </LinearLayout>
 
@@ -71,19 +77,21 @@
                 android:layout_height="wrap_content"
                 android:text="@string/work_orders_work_order_label"
                 android:textAppearance="@android:style/TextAppearance.Small"
+                android:textColor="@color/terminal_on_background"
                 android:textStyle="bold" />
 
             <TextView
                 android:id="@+id/textWorkOrderValue"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@android:drawable/editbox_background"
+                android:background="@drawable/input_field_background"
                 android:clickable="true"
                 android:focusable="true"
                 android:gravity="center"
                 android:padding="16dp"
                 android:text="@string/default_input_placeholder"
                 android:textAppearance="@android:style/TextAppearance.Large"
+                android:textColor="@color/terminal_on_background"
                 android:textStyle="bold" />
         </LinearLayout>
 
@@ -107,6 +115,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="1"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -119,6 +128,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="2"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -131,6 +141,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="3"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -143,6 +154,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="4"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -155,6 +167,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="5"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -167,6 +180,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="6"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -179,6 +193,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="7"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -191,6 +206,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="8"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -203,6 +219,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="9"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -214,6 +231,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="@string/clear"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="20sp" />
 
             <Button
@@ -226,6 +244,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="0"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="24sp" />
 
             <Button
@@ -237,6 +256,7 @@
                 android:minHeight="96dp"
                 android:minWidth="0dp"
                 android:text="@string/enter"
+                android:textColor="@color/terminal_on_background"
                 android:textSize="20sp" />
         </GridLayout>
 
@@ -245,16 +265,20 @@
             android:layout_width="match_parent"
             android:layout_height="72dp"
             android:layout_marginBottom="16dp"
+            android:background="@drawable/rounded_button_background"
             android:text="@string/button_clock_in_wo"
             android:textAllCaps="false"
+            android:textColor="@color/terminal_on_background"
             android:textSize="20sp" />
 
         <Button
             android:id="@+id/buttonClockOutWo"
             android:layout_width="match_parent"
             android:layout_height="72dp"
+            android:background="@drawable/rounded_button_background"
             android:text="@string/button_clock_out_wo"
             android:textAllCaps="false"
+            android:textColor="@color/terminal_on_background"
             android:textSize="20sp" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,7 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="terminal_background">#FF55575A</color>
+    <color name="terminal_on_background">#FFFFFFFF</color>
+    <color name="terminal_primary">#FF76797C</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Terminal" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.Terminal" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:windowBackground">@color/terminal_background</item>
+        <item name="android:colorBackground">@color/terminal_background</item>
+        <item name="android:textColor">@color/terminal_on_background</item>
+        <item name="android:textColorPrimary">@color/terminal_on_background</item>
+        <item name="android:textColorSecondary">@color/terminal_on_background</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Summary
- enforce the #55575A background and white text palette through the Compose theme and UI components
- update XML layouts, colors, and drawable resources to match the dark terminal styling across classic views

## Testing
- ./gradlew lint *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1923dec083319fa2d7e8e00f4c80