### PR TITLE
Fix keypad items lambda type inference

### DIFF
--- a/app/src/main/java/com/example/terminal/TerminalApp.kt
+++ b/app/src/main/java/com/example/terminal/TerminalApp.kt
@@ -361,7 +361,8 @@ private fun NumericKeypad(
             horizontalArrangement = Arrangement.spacedBy(24.dp),
             userScrollEnabled = false
         ) {
-            items(keypadItems, key = { it.first }) { (label, action) ->
+            items(keypadItems, key = { item -> item.first }) { item ->
+                val (label, action) = item
                 KeypadButton(
                     label = label,
                     onClick = action


### PR DESCRIPTION
## Summary
- avoid destructuring parameters directly within LazyVerticalGrid items to keep type inference working
- unpack keypad item pairs inside the lambda before rendering KeypadButton

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc227429948331933bd91987bee199