### PR TITLE
Define MaterialInputField enum for Issue Materials flow

### DIFF
--- a/app/src/main/java/com/example/terminal/TerminalApp.kt
+++ b/app/src/main/java/com/example/terminal/TerminalApp.kt
@@ -315,6 +315,11 @@ private fun IssueMaterialsTabContent(
     }
 }
 
+private enum class MaterialInputField {
+    EMPLOYEE,
+    MATERIAL
+}
+
 @Composable
 private fun DisplayValue(label: String, value: String) {
     Text(


### PR DESCRIPTION
## Summary
- add a MaterialInputField enum to model the Issue Materials input workflow
- keep the currentField state backed by the enum so rememberSaveable can infer the type

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc256c99fc8331b6435d32f65828a7