### PR TITLE
Fix status dropdown to use Material3 DropdownMenu

### DIFF
--- a/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersScreen.kt
+++ b/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersScreen.kt
@@ -25,9 +25,9 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenu
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
@@ -408,7 +408,7 @@ private fun StatusDropdown(
             label = { Text(text = "Status") },
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) }
         )
-        ExposedDropdownMenu(
+        DropdownMenu(
             expanded = expanded,
             onDismissRequest = { onExpandedChange(false) }
         ) {


### PR DESCRIPTION
## Summary
- replace the ExposedDropdownMenu usage with DropdownMenu so the status selector compiles against the current Material3 version
- update the imports in WorkOrdersScreen to match the new dropdown implementation

## Testing
- ./gradlew :app:lint *(fails: SDK location not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc262b65948331a1f69a7e852d02ec