### PR TITLE
Fix KeyboardOptions import in WorkOrdersScreen

### DIFF
--- a/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersScreen.kt
+++ b/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersScreen.kt
@@ -52,7 +52,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp


### PR DESCRIPTION
## Summary
- fix the unresolved reference to KeyboardOptions by importing it from androidx.compose.foundation.text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc28010378833181029b145f7db74b