### PR TITLE
Add server settings dialog to configure API base URL

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.retrofit)
     implementation(libs.retrofit.converter.gson)

--- a/app/src/main/java/com/example/terminal/data/local/UserPrefs.kt
+++ b/app/src/main/java/com/example/terminal/data/local/UserPrefs.kt
@@ -6,11 +6,13 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.example.terminal.data.network.ApiClient
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 private const val DATA_STORE_NAME = "user_prefs"
 private val LAST_EMPLOYEE_KEY = stringPreferencesKey("last_employee_id")
+private val SERVER_ADDRESS_KEY = stringPreferencesKey("server_address")
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = DATA_STORE_NAME)
 
@@ -21,9 +23,20 @@ class UserPrefs private constructor(private val appContext: Context) {
             preferences[LAST_EMPLOYEE_KEY]
         }
 
+    val serverAddress: Flow<String>
+        get() = appContext.dataStore.data.map { preferences ->
+            preferences[SERVER_ADDRESS_KEY] ?: ApiClient.DEFAULT_BASE_URL
+        }
+
     suspend fun saveLastEmployeeId(employeeId: String) {
         appContext.dataStore.edit { preferences ->
             preferences[LAST_EMPLOYEE_KEY] = employeeId
+        }
+    }
+
+    suspend fun saveServerAddress(address: String) {
+        appContext.dataStore.edit { preferences ->
+            preferences[SERVER_ADDRESS_KEY] = address
         }
     }
 

--- a/app/src/main/java/com/example/terminal/data/repository/WorkOrdersRepository.kt
+++ b/app/src/main/java/com/example/terminal/data/repository/WorkOrdersRepository.kt
@@ -1,16 +1,18 @@
 package com.example.terminal.data.repository
 
+import com.example.terminal.data.local.UserPrefs
+import com.example.terminal.data.network.ApiClient
 import com.example.terminal.data.network.ApiResponse
-import com.example.terminal.data.network.ApiService
 import com.example.terminal.data.network.ClockInRequest
 import com.example.terminal.data.network.ClockOutRequest
 import com.example.terminal.data.network.ClockOutStatus
 import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.first
 
 class WorkOrdersRepository(
-    private val apiService: ApiService,
+    private val userPrefs: UserPrefs,
     private val gson: Gson = Gson()
 ) {
     suspend fun clockIn(
@@ -18,7 +20,9 @@ class WorkOrdersRepository(
         userId: Int,
         qty: Int
     ): Result<ApiResponse> = withContext(Dispatchers.IO) {
+        val baseUrl = userPrefs.serverAddress.first()
         runCatching {
+            val apiService = ApiClient.getApiService(baseUrl)
             val response = apiService.clockIn(
                 ClockInRequest(
                     workOrderCollectionId = workOrderCollectionId,
@@ -42,7 +46,9 @@ class WorkOrdersRepository(
         qty: Int,
         status: ClockOutStatus
     ): Result<ApiResponse> = withContext(Dispatchers.IO) {
+        val baseUrl = userPrefs.serverAddress.first()
         runCatching {
+            val apiService = ApiClient.getApiService(baseUrl)
             val response = apiService.clockOut(
                 ClockOutRequest(
                     workOrderCollectionId = workOrderCollectionId,

--- a/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersViewModel.kt
+++ b/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.example.terminal.data.local.UserPrefs
-import com.example.terminal.data.network.ApiClient
 import com.example.terminal.data.network.ClockOutStatus
 import com.example.terminal.data.repository.WorkOrdersRepository
 import kotlinx.coroutines.Job
@@ -202,9 +201,8 @@ class WorkOrdersViewModel(
             return object : ViewModelProvider.Factory {
                 @Suppress("UNCHECKED_CAST")
                 override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                    val apiService = ApiClient.getApiService()
-                    val repository = WorkOrdersRepository(apiService)
                     val userPrefs = UserPrefs.create(appContext)
+                    val repository = WorkOrdersRepository(userPrefs)
                     return WorkOrdersViewModel(repository, userPrefs) as T
                 }
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-material-iconsExtended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }


### PR DESCRIPTION
## Summary
- add a settings icon in the main tab bar that opens a dialog to edit the server address
- persist the server URL with DataStore and use it when building Retrofit clients
- include the compose material icons dependency for the new settings action

## Testing
- ./gradlew test *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2b70a638833197ff112171786411