### PR TITLE
Implement token provider for authenticated requests

### DIFF
--- a/app/src/main/java/com/example/terminal/data/auth/AuthToken.kt
+++ b/app/src/main/java/com/example/terminal/data/auth/AuthToken.kt
@@ -1,0 +1,15 @@
+package com.example.terminal.data.auth
+
+/**
+ * Represents an authentication token along with its optional expiration date expressed in
+ * epoch seconds.
+ */
+data class AuthToken(
+    val value: String,
+    val expiresAtEpochSeconds: Long? = null
+) {
+    fun isExpired(currentEpochSeconds: Long = System.currentTimeMillis() / 1000): Boolean {
+        val expiresAt = expiresAtEpochSeconds ?: return false
+        return currentEpochSeconds >= expiresAt
+    }
+}

--- a/app/src/main/java/com/example/terminal/data/auth/DataStoreTokenProvider.kt
+++ b/app/src/main/java/com/example/terminal/data/auth/DataStoreTokenProvider.kt
@@ -1,0 +1,108 @@
+package com.example.terminal.data.auth
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import java.io.IOException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+private const val DATA_STORE_NAME = "auth_tokens"
+private val TOKEN_KEY = stringPreferencesKey("jwt")
+private val TOKEN_EXPIRATION_KEY = longPreferencesKey("jwt_expiration")
+
+private val Context.authDataStore: DataStore<Preferences> by preferencesDataStore(name = DATA_STORE_NAME)
+
+/**
+ * DataStore backed implementation for [TokenProvider].
+ */
+class DataStoreTokenProvider private constructor(private val appContext: Context) : TokenProvider {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val _tokenState = MutableStateFlow<AuthToken?>(null)
+
+    override val tokenFlow: StateFlow<AuthToken?> = _tokenState.asStateFlow()
+
+    init {
+        scope.launch {
+            appContext.authDataStore.data
+                .map { preferences ->
+                    val token = preferences[TOKEN_KEY]
+                    val expiration = preferences[TOKEN_EXPIRATION_KEY]
+                    token?.let { AuthToken(it, expiration) }
+                }
+                .catch { exception ->
+                    if (exception is IOException) {
+                        _tokenState.value = null
+                    } else {
+                        throw exception
+                    }
+                }
+                .collect { token ->
+                    if (token?.isExpired() == true) {
+                        clearTokenInternal()
+                    } else {
+                        _tokenState.value = token
+                    }
+                }
+        }
+    }
+
+    override fun getCachedToken(): AuthToken? {
+        val cached = _tokenState.value
+        if (cached?.isExpired() == true) {
+            scope.launch { clearTokenInternal() }
+            return null
+        }
+        return cached
+    }
+
+    override suspend fun persistToken(token: AuthToken) {
+        clearTokenInternal()
+        appContext.authDataStore.edit { preferences ->
+            preferences[TOKEN_KEY] = token.value
+            val expiration = token.expiresAtEpochSeconds
+            if (expiration != null) {
+                preferences[TOKEN_EXPIRATION_KEY] = expiration
+            } else {
+                preferences.remove(TOKEN_EXPIRATION_KEY)
+            }
+        }
+        _tokenState.value = token
+    }
+
+    override suspend fun invalidateToken() {
+        clearTokenInternal()
+        _tokenState.value = null
+    }
+
+    private suspend fun clearTokenInternal() {
+        appContext.authDataStore.edit { preferences ->
+            preferences.remove(TOKEN_KEY)
+            preferences.remove(TOKEN_EXPIRATION_KEY)
+        }
+    }
+
+    companion object {
+        @Volatile
+        private var instance: DataStoreTokenProvider? = null
+
+        fun getInstance(context: Context): DataStoreTokenProvider {
+            val appContext = context.applicationContext
+            return instance ?: synchronized(this) {
+                instance ?: DataStoreTokenProvider(appContext).also { instance = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/terminal/data/auth/TokenProvider.kt
+++ b/app/src/main/java/com/example/terminal/data/auth/TokenProvider.kt
@@ -1,0 +1,22 @@
+package com.example.terminal.data.auth
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Contract for providing authentication tokens to the networking layer.
+ */
+interface TokenProvider {
+    /** Emits updates for the currently persisted token. */
+    val tokenFlow: StateFlow<AuthToken?>
+
+    /** Returns the cached token if present and still valid. */
+    fun getCachedToken(): AuthToken?
+
+    /**
+     * Persists the provided [token] replacing any previous session and notifying observers.
+     */
+    suspend fun persistToken(token: AuthToken)
+
+    /** Clears the stored token and notifies observers. */
+    suspend fun invalidateToken()
+}

--- a/app/src/main/java/com/example/terminal/data/auth/TokenRefreshHandler.kt
+++ b/app/src/main/java/com/example/terminal/data/auth/TokenRefreshHandler.kt
@@ -1,0 +1,10 @@
+package com.example.terminal.data.auth
+
+/**
+ * Allows the networking layer to request a refreshed JWT when the server indicates that the
+ * current token is no longer valid. Returning null indicates that a refresh could not be performed
+ * and the request should not be retried.
+ */
+fun interface TokenRefreshHandler {
+    suspend fun refreshToken(currentToken: AuthToken?): AuthToken?
+}

--- a/app/src/main/java/com/example/terminal/data/network/ApiClient.kt
+++ b/app/src/main/java/com/example/terminal/data/network/ApiClient.kt
@@ -1,25 +1,63 @@
 package com.example.terminal.data.network
 
+import com.example.terminal.data.auth.TokenProvider
+import com.example.terminal.data.auth.TokenRefreshHandler
+import kotlinx.coroutines.runBlocking
+import okhttp3.Authenticator
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import okhttp3.Request
 import okhttp3.Response
+import okhttp3.Route
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
 
-class AuthInterceptor : Interceptor {
+class AuthInterceptor(private val tokenProvider: TokenProvider) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val token = getToken()
         val requestBuilder = chain.request().newBuilder()
-        if (token.isNotBlank()) {
-            requestBuilder.addHeader("Authorization", "Bearer $token")
+        tokenProvider.getCachedToken()?.let { token ->
+            requestBuilder.addHeader("Authorization", "Bearer ${token.value}")
         }
+
         return chain.proceed(requestBuilder.build())
     }
 }
 
-fun getToken(): String = "REPLACE_WITH_REAL_TOKEN" // TODO integrar con login.
+private class TokenRefreshAuthenticator(
+    private val tokenProvider: TokenProvider,
+    private val refreshHandler: TokenRefreshHandler
+) : Authenticator {
+    override fun authenticate(route: Route?, response: Response): Request? {
+        if (responseCount(response) >= 2) {
+            runBlocking { tokenProvider.invalidateToken() }
+            return null
+        }
+
+        val currentToken = tokenProvider.getCachedToken()
+        val refreshed = runBlocking { refreshHandler.refreshToken(currentToken) }
+        return if (refreshed != null && refreshed.value.isNotBlank()) {
+            runBlocking { tokenProvider.persistToken(refreshed) }
+            response.request.newBuilder()
+                .header("Authorization", "Bearer ${refreshed.value}")
+                .build()
+        } else {
+            runBlocking { tokenProvider.invalidateToken() }
+            null
+        }
+    }
+
+    private fun responseCount(response: Response): Int {
+        var current: Response? = response
+        var count = 1
+        while (current?.priorResponse != null) {
+            current = current.priorResponse
+            count++
+        }
+        return count
+    }
+}
 
 object ApiClient {
     const val DEFAULT_BASE_URL = "http://<IP-SERVER>:8080/"
@@ -28,8 +66,23 @@ object ApiClient {
     private var apiService: ApiService? = null
     @Volatile
     private var currentBaseUrl: String = DEFAULT_BASE_URL
+    @Volatile
+    private var tokenProvider: TokenProvider? = null
+    @Volatile
+    private var tokenRefreshHandler: TokenRefreshHandler = TokenRefreshHandler { null }
+
+    fun configure(
+        provider: TokenProvider,
+        refreshHandler: TokenRefreshHandler = TokenRefreshHandler { null }
+    ) {
+        tokenProvider = provider
+        tokenRefreshHandler = refreshHandler
+        synchronized(this) { apiService = null }
+    }
 
     fun getApiService(baseUrl: String = currentBaseUrl): ApiService {
+        val provider = tokenProvider
+            ?: throw IllegalStateException("TokenProvider must be configured before creating ApiService")
         if (baseUrl != currentBaseUrl) {
             synchronized(this) {
                 if (baseUrl != currentBaseUrl) {
@@ -39,7 +92,7 @@ object ApiClient {
             }
         }
         return apiService ?: synchronized(this) {
-            apiService ?: buildRetrofit(currentBaseUrl).also { apiService = it }
+            apiService ?: buildRetrofit(currentBaseUrl, provider).also { apiService = it }
         }
     }
 
@@ -50,13 +103,14 @@ object ApiClient {
         }
     }
 
-    private fun buildRetrofit(baseUrl: String): ApiService {
+    private fun buildRetrofit(baseUrl: String, provider: TokenProvider): ApiService {
         val loggingInterceptor = HttpLoggingInterceptor().apply {
             level = HttpLoggingInterceptor.Level.BODY
         }
 
         val client = OkHttpClient.Builder()
-            .addInterceptor(AuthInterceptor())
+            .addInterceptor(AuthInterceptor(provider))
+            .authenticator(TokenRefreshAuthenticator(provider, tokenRefreshHandler))
             .addInterceptor(loggingInterceptor)
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)

--- a/app/src/main/java/com/example/terminal/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/terminal/data/repository/AuthRepository.kt
@@ -1,0 +1,24 @@
+package com.example.terminal.data.repository
+
+import com.example.terminal.data.auth.AuthToken
+import com.example.terminal.data.auth.TokenProvider
+import kotlinx.coroutines.flow.StateFlow
+
+class AuthRepository(
+    private val tokenProvider: TokenProvider
+) {
+
+    val activeToken: StateFlow<AuthToken?> = tokenProvider.tokenFlow
+
+    suspend fun persistSession(token: String, expiresAtEpochSeconds: Long? = null) {
+        tokenProvider.persistToken(AuthToken(token, expiresAtEpochSeconds))
+    }
+
+    suspend fun persistSession(token: AuthToken) {
+        tokenProvider.persistToken(token)
+    }
+
+    suspend fun invalidateSession() {
+        tokenProvider.invalidateToken()
+    }
+}

--- a/app/src/main/java/com/example/terminal/data/repository/WorkOrdersRepository.kt
+++ b/app/src/main/java/com/example/terminal/data/repository/WorkOrdersRepository.kt
@@ -1,5 +1,7 @@
 package com.example.terminal.data.repository
 
+import com.example.terminal.data.auth.TokenProvider
+import com.example.terminal.data.auth.TokenRefreshHandler
 import com.example.terminal.data.local.UserPrefs
 import com.example.terminal.data.network.ApiClient
 import com.example.terminal.data.network.ApiResponse
@@ -8,13 +10,19 @@ import com.example.terminal.data.network.ClockOutRequest
 import com.example.terminal.data.network.ClockOutStatus
 import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
 
 class WorkOrdersRepository(
     private val userPrefs: UserPrefs,
+    private val tokenProvider: TokenProvider,
+    private val refreshHandler: TokenRefreshHandler = TokenRefreshHandler { null },
     private val gson: Gson = Gson()
 ) {
+
+    init {
+        ApiClient.configure(tokenProvider, refreshHandler)
+    }
     suspend fun clockIn(
         workOrderCollectionId: Int,
         userId: Int,

--- a/app/src/main/java/com/example/terminal/di/AppContainer.kt
+++ b/app/src/main/java/com/example/terminal/di/AppContainer.kt
@@ -1,0 +1,35 @@
+package com.example.terminal.di
+
+import android.content.Context
+import com.example.terminal.data.auth.DataStoreTokenProvider
+import com.example.terminal.data.auth.TokenProvider
+import com.example.terminal.data.local.UserPrefs
+import com.example.terminal.data.network.ApiClient
+import com.example.terminal.data.repository.AuthRepository
+import com.example.terminal.data.repository.WorkOrdersRepository
+
+object AppContainer {
+    @Volatile
+    private var tokenProvider: TokenProvider? = null
+
+    fun tokenProvider(context: Context): TokenProvider {
+        val appContext = context.applicationContext
+        return tokenProvider ?: synchronized(this) {
+            tokenProvider ?: DataStoreTokenProvider.getInstance(appContext).also { provider ->
+                tokenProvider = provider
+                ApiClient.configure(provider)
+            }
+        }
+    }
+
+    fun authRepository(context: Context): AuthRepository {
+        return AuthRepository(tokenProvider(context))
+    }
+
+    fun workOrdersRepository(
+        context: Context,
+        userPrefs: UserPrefs = UserPrefs.create(context.applicationContext)
+    ): WorkOrdersRepository {
+        return WorkOrdersRepository(userPrefs, tokenProvider(context))
+    }
+}

--- a/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersViewModel.kt
+++ b/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.terminal.data.local.UserPrefs
 import com.example.terminal.data.network.ClockOutStatus
 import com.example.terminal.data.repository.WorkOrdersRepository
+import com.example.terminal.di.AppContainer
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -202,7 +203,7 @@ class WorkOrdersViewModel(
                 @Suppress("UNCHECKED_CAST")
                 override fun <T : ViewModel> create(modelClass: Class<T>): T {
                     val userPrefs = UserPrefs.create(appContext)
-                    val repository = WorkOrdersRepository(userPrefs)
+                    val repository = AppContainer.workOrdersRepository(appContext, userPrefs)
                     return WorkOrdersViewModel(repository, userPrefs) as T
                 }
             }


### PR DESCRIPTION
## Summary
- add a DataStore-backed token provider with invalidation support and expose it through a simple auth repository
- inject the provider into ApiClient, wiring an AuthInterceptor and refresh-aware Authenticator via a lightweight app container
- update the work orders repository/view model factory to resolve their dependencies through the container

## Testing
- `./gradlew lint` *(fails: Android SDK is not configured in the CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0c792d408331a4c5a983ab3f3d19