### PR TITLE
Handle API status for clock in/out operations

### DIFF
--- a/app/src/main/java/com/example/terminal/data/repository/WorkOrdersRepository.kt
+++ b/app/src/main/java/com/example/terminal/data/repository/WorkOrdersRepository.kt
@@ -32,7 +32,14 @@ class WorkOrdersRepository(
             )
 
             if (response.isSuccessful) {
-                response.body() ?: throw IllegalStateException("Respuesta vacía del servidor")
+                val body = response.body() ?: throw IllegalStateException("Respuesta vacía del servidor")
+                if (body.status == "success") {
+                    body
+                } else {
+                    val message = body.message.takeIf { it.isNotBlank() }
+                        ?: "La operación de Clock In no se completó correctamente"
+                    throw IllegalStateException(message)
+                }
             } else {
                 val errorMessage = parseError(response.errorBody()?.string())
                 throw IllegalStateException(errorMessage)
@@ -59,7 +66,14 @@ class WorkOrdersRepository(
             )
 
             if (response.isSuccessful) {
-                response.body() ?: throw IllegalStateException("Respuesta vacía del servidor")
+                val body = response.body() ?: throw IllegalStateException("Respuesta vacía del servidor")
+                if (body.status == "success") {
+                    body
+                } else {
+                    val message = body.message.takeIf { it.isNotBlank() }
+                        ?: "La operación de Clock Out no se completó correctamente"
+                    throw IllegalStateException(message)
+                }
             } else {
                 val errorMessage = parseError(response.errorBody()?.string())
                 throw IllegalStateException(errorMessage)

--- a/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersViewModel.kt
+++ b/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersViewModel.kt
@@ -115,10 +115,14 @@ class WorkOrdersViewModel(
         viewModelScope.launch {
             repository.clockIn(workOrderId, employeeId, DEFAULT_CLOCK_IN_QTY)
                 .onSuccess { response ->
-                    showMessage(response.message)
+                    val message = response.message.takeIf { it.isNotBlank() }
+                        ?: "Clock In registrado correctamente"
+                    showMessage(message)
                 }
                 .onFailure { error ->
-                    showMessage(error.message ?: "Error al registrar Clock In")
+                    val message = error.message?.takeIf { it.isNotBlank() }
+                        ?: "Error al registrar Clock In"
+                    showMessage(message)
                 }
             setLoading(false)
         }
@@ -156,10 +160,14 @@ class WorkOrdersViewModel(
         viewModelScope.launch {
             repository.clockOut(workOrderId, employeeId, quantity, status)
                 .onSuccess { response ->
-                    showMessage(response.message)
+                    val message = response.message.takeIf { it.isNotBlank() }
+                        ?: "Clock Out registrado correctamente"
+                    showMessage(message)
                 }
                 .onFailure { error ->
-                    showMessage(error.message ?: "Error al registrar Clock Out")
+                    val message = error.message?.takeIf { it.isNotBlank() }
+                        ?: "Error al registrar Clock Out"
+                    showMessage(message)
                 }
             setLoading(false)
         }


### PR DESCRIPTION
## Summary
- validate that clock in/out API responses report success before returning to callers
- surface API-provided error messages when the status is not success
- update the work orders view model to show default success and error messages when needed

## Testing
- ./gradlew test *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0fef5c448331816291d3232ca288