### PR TITLE
Handle API status errors for work order clock actions

### DIFF
--- a/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersViewModel.kt
+++ b/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersViewModel.kt
@@ -114,13 +114,15 @@ class WorkOrdersViewModel(
 
         setLoading(true)
         viewModelScope.launch {
-            repository.clockIn(workOrderId, employeeId, DEFAULT_CLOCK_IN_QTY)
-                .onSuccess { response ->
+            val result = repository.clockIn(workOrderId, employeeId, DEFAULT_CLOCK_IN_QTY)
+            result.fold(
+                onSuccess = { response ->
                     showMessage(response.message)
-                }
-                .onFailure { error ->
+                },
+                onFailure = { error ->
                     showMessage(error.message ?: "Error al registrar Clock In")
                 }
+            )
             setLoading(false)
         }
     }
@@ -155,13 +157,15 @@ class WorkOrdersViewModel(
         setLoading(true)
         _uiState.update { it.copy(showClockOutDialog = false) }
         viewModelScope.launch {
-            repository.clockOut(workOrderId, employeeId, quantity, status)
-                .onSuccess { response ->
+            val result = repository.clockOut(workOrderId, employeeId, quantity, status)
+            result.fold(
+                onSuccess = { response ->
                     showMessage(response.message)
-                }
-                .onFailure { error ->
+                },
+                onFailure = { error ->
                     showMessage(error.message ?: "Error al registrar Clock Out")
                 }
+            )
             setLoading(false)
         }
     }


### PR DESCRIPTION
## Summary
- validate API responses in the work orders repository and surface failures when the status is not `success`
- forward failure messages to the UI by folding results in the work orders view model

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd108559e08331bc7f72bcaaf915a8