### PR TITLE
Allow cleartext traffic to local server

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:usesCleartextTraffic="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Terminal">

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.0.147</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## Summary
- reference the new network security configuration allowing cleartext calls to 10.0.0.147
- point the application to use the custom network security config and enable cleartext traffic

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd140d6dbc8331a50ee1e8e4ba5e88