### PR TITLE
Normalize server URL handling and expand cleartext allowance

### DIFF
--- a/app/src/main/java/com/example/terminal/data/local/UserPrefs.kt
+++ b/app/src/main/java/com/example/terminal/data/local/UserPrefs.kt
@@ -25,7 +25,8 @@ class UserPrefs private constructor(private val appContext: Context) {
 
     val serverAddress: Flow<String>
         get() = appContext.dataStore.data.map { preferences ->
-            preferences[SERVER_ADDRESS_KEY] ?: ApiClient.DEFAULT_BASE_URL
+            val savedAddress = preferences[SERVER_ADDRESS_KEY] ?: ApiClient.DEFAULT_BASE_URL
+            ApiClient.normalizeBaseUrl(savedAddress)
         }
 
     suspend fun saveLastEmployeeId(employeeId: String) {
@@ -35,8 +36,9 @@ class UserPrefs private constructor(private val appContext: Context) {
     }
 
     suspend fun saveServerAddress(address: String) {
+        val normalizedAddress = ApiClient.normalizeBaseUrl(address)
         appContext.dataStore.edit { preferences ->
-            preferences[SERVER_ADDRESS_KEY] = address
+            preferences[SERVER_ADDRESS_KEY] = normalizedAddress
         }
     }
 

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="false">10.0.0.147</domain>
-    </domain-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
 </network-security-config>


### PR DESCRIPTION
## Summary
- normalize the configured server URL so retrofit always receives a well-formed base address
- persist the normalized server address in DataStore to keep the saved value consistent
- relax the network security config to permit cleartext traffic for any configured host

## Testing
- ./gradlew test *(fails: Android SDK not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1f75be608331a5e7b9ae839f34a7