### PR TITLE
Add internet permission for network access

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"


### PR DESCRIPTION
## Summary
- add the INTERNET permission to the Android manifest so the app can create network sockets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd22c7f11c83319ffc6dc39edd9dce