### PR TITLE
Align clock in/out payloads with backend contract

### DIFF
--- a/app/src/main/java/com/example/terminal/data/network/Models.kt
+++ b/app/src/main/java/com/example/terminal/data/network/Models.kt
@@ -3,16 +3,21 @@ package com.example.terminal.data.network
 import com.google.gson.annotations.SerializedName
 
 data class ClockInRequest(
-    @SerializedName("workOrderCollectionId") val workOrderCollectionId: Int,
+    @SerializedName("workOrderAssemblyId") val workOrderAssemblyId: Int,
     @SerializedName("userId") val userId: Int,
-    @SerializedName("qty") val qty: Int
+    @SerializedName("divisionFK") val divisionFK: Int,
+    @SerializedName("deviceDate") val deviceDate: String
 )
 
 data class ClockOutRequest(
     @SerializedName("workOrderCollectionId") val workOrderCollectionId: Int,
-    @SerializedName("userId") val userId: Int,
-    @SerializedName("qty") val qty: Int,
-    @SerializedName("status") val status: String
+    @SerializedName("quantity") val quantity: Int,
+    @SerializedName("quantityScrapped") val quantityScrapped: Int,
+    @SerializedName("scrapReasonPK") val scrapReasonPK: Int,
+    @SerializedName("complete") val complete: Boolean,
+    @SerializedName("comment") val comment: String,
+    @SerializedName("deviceTime") val deviceTime: String,
+    @SerializedName("divisionFK") val divisionFK: Int
 )
 
 data class ApiResponse(
@@ -20,9 +25,9 @@ data class ApiResponse(
     @SerializedName("message") val message: String
 )
 
-enum class ClockOutStatus(val apiValue: String) {
-    COMPLETE("Complete"),
-    INCOMPLETE("Incomplete");
+enum class ClockOutStatus(val isComplete: Boolean, val displayName: String) {
+    COMPLETE(true, "Complete"),
+    INCOMPLETE(false, "Incomplete");
 
-    override fun toString(): String = apiValue
+    override fun toString(): String = displayName
 }

--- a/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersScreen.kt
+++ b/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersScreen.kt
@@ -404,7 +404,7 @@ private fun StatusDropdown(
                 .fillMaxWidth()
                 .menuAnchor(),
             readOnly = true,
-            value = selectedStatus.apiValue,
+            value = selectedStatus.displayName,
             onValueChange = {},
             label = { Text(text = "Status") },
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) }
@@ -415,7 +415,7 @@ private fun StatusDropdown(
         ) {
             ClockOutStatus.entries.forEach { status ->
                 DropdownMenuItem(
-                    text = { Text(text = status.apiValue) },
+                    text = { Text(text = status.displayName) },
                     onClick = { onStatusSelected(status) }
                 )
             }

--- a/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersViewModel.kt
+++ b/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersViewModel.kt
@@ -16,8 +16,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-private const val DEFAULT_CLOCK_IN_QTY = 1
-
 enum class WorkOrderInputField {
     EMPLOYEE,
     WORK_ORDER
@@ -114,7 +112,7 @@ class WorkOrdersViewModel(
 
         setLoading(true)
         viewModelScope.launch {
-            val result = repository.clockIn(workOrderId, employeeId, DEFAULT_CLOCK_IN_QTY)
+            val result = repository.clockIn(workOrderId, employeeId)
             result.fold(
                 onSuccess = { response ->
                     showMessage(response.message)
@@ -157,7 +155,11 @@ class WorkOrdersViewModel(
         setLoading(true)
         _uiState.update { it.copy(showClockOutDialog = false) }
         viewModelScope.launch {
-            val result = repository.clockOut(workOrderId, employeeId, quantity, status)
+            val result = repository.clockOut(
+                workOrderCollectionId = workOrderId,
+                quantity = quantity,
+                complete = status.isComplete
+            )
             result.fold(
                 onSuccess = { response ->
                     showMessage(response.message)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+
+from .models import ApiResponse, ClockInRequest, ClockOutRequest
+
+app = FastAPI()
+
+
+@app.post("/clock-in", response_model=ApiResponse)
+async def clock_in(request: ClockInRequest) -> ApiResponse:
+    return ApiResponse(status="success", message="Clock In registrado correctamente")
+
+
+@app.post("/clock-out", response_model=ApiResponse)
+async def clock_out(request: ClockOutRequest) -> ApiResponse:
+    status_message = "Clock Out completado" if request.complete else "Clock Out pendiente"
+    return ApiResponse(status="success", message=status_message)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, validator
+
+
+class StrictBaseModel(BaseModel):
+    class Config:
+        extra = "forbid"
+
+
+class ApiResponse(StrictBaseModel):
+    status: str
+    message: str
+
+
+class ClockInRequest(StrictBaseModel):
+    workOrderAssemblyId: int
+    userId: int
+    divisionFK: Literal[1]
+    deviceDate: str
+
+    @validator("deviceDate")
+    def validate_device_date(cls, value: str) -> str:
+        _ensure_iso_datetime(value)
+        return value
+
+
+class ClockOutRequest(StrictBaseModel):
+    workOrderCollectionId: int
+    quantity: int
+    quantityScrapped: int
+    scrapReasonPK: int
+    complete: bool
+    comment: str
+    deviceTime: str
+    divisionFK: Literal[1]
+
+    @validator("deviceTime")
+    def validate_device_time(cls, value: str) -> str:
+        _ensure_iso_datetime(value)
+        return value
+
+
+def _ensure_iso_datetime(value: str) -> None:
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("Value must be a valid ISO 8601 datetime string") from exc


### PR DESCRIPTION
## Summary
- update the Android network models and Retrofit calls to match the new clock in/out payload contract and auto-generate ISO timestamps
- adjust repository and view model logic to always send divisionFK=1 and map UI status selections to the new completion flag
- add FastAPI models and endpoints that validate the exact clock in/out request schemas expected by the backend

## Testing
- ./gradlew test *(fails: SDK location not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3b7459d88331addcb1d87d5ff5c7