### PR TITLE
Handle null API response messages safely

### DIFF
--- a/app/src/main/java/com/example/terminal/data/network/Models.kt
+++ b/app/src/main/java/com/example/terminal/data/network/Models.kt
@@ -22,7 +22,7 @@ data class ClockOutRequest(
 
 data class ApiResponse(
     @SerializedName("status") val status: String,
-    @SerializedName("message") val message: String
+    @SerializedName("message") val message: String?
 )
 
 enum class ClockOutStatus(val isComplete: Boolean, val displayName: String) {

--- a/app/src/main/java/com/example/terminal/data/repository/WorkOrdersRepository.kt
+++ b/app/src/main/java/com/example/terminal/data/repository/WorkOrdersRepository.kt
@@ -42,7 +42,7 @@ class WorkOrdersRepository(
                 when {
                     body == null -> Result.failure(IllegalStateException("Respuesta vacía del servidor"))
                     body.status != "success" -> {
-                        val message = body.message.takeIf { it.isNotBlank() }
+                        val message = body.message?.takeIf { it.isNotBlank() }
                             ?: "Operación de Clock In rechazada por el servidor"
                         Result.failure(IllegalStateException(message))
                     }
@@ -86,7 +86,7 @@ class WorkOrdersRepository(
                 when {
                     body == null -> Result.failure(IllegalStateException("Respuesta vacía del servidor"))
                     body.status != "success" -> {
-                        val message = body.message.takeIf { it.isNotBlank() }
+                        val message = body.message?.takeIf { it.isNotBlank() }
                             ?: "Operación de Clock Out rechazada por el servidor"
                         Result.failure(IllegalStateException(message))
                     }

--- a/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersViewModel.kt
+++ b/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersViewModel.kt
@@ -115,7 +115,9 @@ class WorkOrdersViewModel(
             val result = repository.clockIn(workOrderId, employeeId)
             result.fold(
                 onSuccess = { response ->
-                    showMessage(response.message)
+                    val successMessage = response.message?.takeIf { it.isNotBlank() }
+                        ?: "Clock In registrado correctamente"
+                    showMessage(successMessage)
                 },
                 onFailure = { error ->
                     showMessage(error.message ?: "Error al registrar Clock In")
@@ -162,7 +164,9 @@ class WorkOrdersViewModel(
             )
             result.fold(
                 onSuccess = { response ->
-                    showMessage(response.message)
+                    val successMessage = response.message?.takeIf { it.isNotBlank() }
+                        ?: "Clock Out registrado correctamente"
+                    showMessage(successMessage)
                 },
                 onFailure = { error ->
                     showMessage(error.message ?: "Error al registrar Clock Out")


### PR DESCRIPTION
## Summary
- allow API response messages to be nullable so unexpected null payloads do not crash the app
- guard work order repository error handling against missing messages
- provide fallback success text when the server omits a message during clock in/out flows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd4230701c83319c8acadb715f400d