### PR TITLE
Handle case-insensitive work order success responses

### DIFF
--- a/app/src/main/java/com/example/terminal/data/repository/WorkOrdersRepository.kt
+++ b/app/src/main/java/com/example/terminal/data/repository/WorkOrdersRepository.kt
@@ -41,7 +41,7 @@ class WorkOrdersRepository(
                 val body = response.body()
                 when {
                     body == null -> Result.failure(IllegalStateException("Respuesta vacía del servidor"))
-                    body.status != "success" -> {
+                    !body.hasSuccessStatus() -> {
                         val message = body.message?.takeIf { it.isNotBlank() }
                             ?: "Operación de Clock In rechazada por el servidor"
                         Result.failure(IllegalStateException(message))
@@ -85,7 +85,7 @@ class WorkOrdersRepository(
                 val body = response.body()
                 when {
                     body == null -> Result.failure(IllegalStateException("Respuesta vacía del servidor"))
-                    body.status != "success" -> {
+                    !body.hasSuccessStatus() -> {
                         val message = body.message?.takeIf { it.isNotBlank() }
                             ?: "Operación de Clock Out rechazada por el servidor"
                         Result.failure(IllegalStateException(message))
@@ -123,6 +123,8 @@ class WorkOrdersRepository(
             formatter.format(Date())
         }
     }
+
+    private fun ApiResponse.hasSuccessStatus(): Boolean = status.equals("success", ignoreCase = true)
 
     private companion object {
         const val DIVISION_FK = 1


### PR DESCRIPTION
## Summary
- accept case-insensitive success statuses when clocking in or out of work orders by sharing a helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd47ba7ed883318498a4d7b8c8979f