### PR TITLE
Add employee validation flow to Work Orders tab

### DIFF
--- a/app/src/main/java/com/example/terminal/data/network/ApiService.kt
+++ b/app/src/main/java/com/example/terminal/data/network/ApiService.kt
@@ -2,7 +2,9 @@ package com.example.terminal.data.network
 
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface ApiService {
     @POST("clock-in")
@@ -10,4 +12,7 @@ interface ApiService {
 
     @POST("clock-out")
     suspend fun clockOut(@Body request: ClockOutRequest): Response<ApiResponse>
+
+    @GET("users/{userId}")
+    suspend fun getUserStatus(@Path("userId") userId: Int): Response<UserStatusResponse>
 }

--- a/app/src/main/java/com/example/terminal/data/network/Models.kt
+++ b/app/src/main/java/com/example/terminal/data/network/Models.kt
@@ -25,6 +25,19 @@ data class ApiResponse(
     @SerializedName("message") val message: String?
 )
 
+data class UserStatusResponse(
+    @SerializedName("userId") val userId: Int,
+    @SerializedName("firstName") val firstName: String,
+    @SerializedName("lastName") val lastName: String,
+    @SerializedName("workOrderCollectionId") val workOrderCollectionId: Int?,
+    @SerializedName("workOrderNumber") val workOrderNumber: String?,
+    @SerializedName("workOrderAssemblyNumber") val workOrderAssemblyNumber: String?,
+    @SerializedName("clockInTime") val clockInTime: String?,
+    @SerializedName("partNumber") val partNumber: String?,
+    @SerializedName("operationCode") val operationCode: String?,
+    @SerializedName("operationName") val operationName: String?
+)
+
 enum class ClockOutStatus(val isComplete: Boolean, val displayName: String) {
     COMPLETE(true, "Complete"),
     INCOMPLETE(false, "Incomplete");

--- a/app/src/main/java/com/example/terminal/data/repository/WorkOrdersRepository.kt
+++ b/app/src/main/java/com/example/terminal/data/repository/WorkOrdersRepository.kt
@@ -6,6 +6,7 @@ import com.example.terminal.data.network.ApiClient
 import com.example.terminal.data.network.ApiResponse
 import com.example.terminal.data.network.ClockInRequest
 import com.example.terminal.data.network.ClockOutRequest
+import com.example.terminal.data.network.UserStatusResponse
 import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -16,11 +17,32 @@ import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
+import com.google.gson.annotations.SerializedName
 
 class WorkOrdersRepository(
     private val userPrefs: UserPrefs,
     private val gson: Gson = Gson()
 ) {
+    suspend fun fetchUserStatus(userId: Int): Result<UserStatus> = withContext(Dispatchers.IO) {
+        val baseUrl = userPrefs.serverAddress.first()
+        try {
+            val apiService = ApiClient.getApiService(baseUrl)
+            val response = apiService.getUserStatus(userId)
+            if (response.isSuccessful) {
+                val body = response.body()
+                when (body) {
+                    null -> Result.failure(IllegalStateException("Respuesta vacía del servidor"))
+                    else -> Result.success(body.toDomain())
+                }
+            } else {
+                val errorMessage = parseUserStatusError(response.code(), response.errorBody()?.string())
+                Result.failure(IllegalStateException(errorMessage))
+            }
+        } catch (ex: Exception) {
+            Result.failure(ex)
+        }
+    }
+
     suspend fun clockIn(
         workOrderAssemblyId: Int,
         userId: Int
@@ -114,6 +136,21 @@ class WorkOrdersRepository(
         }
     }
 
+    private fun parseUserStatusError(code: Int, errorBody: String?): String {
+        if (code == 404) {
+            return "Wrong user"
+        }
+        if (errorBody.isNullOrBlank()) {
+            return "Error al validar usuario"
+        }
+        return try {
+            val parsed = gson.fromJson(errorBody, ErrorDetailResponse::class.java)
+            parsed?.detail?.takeIf { it.isNotBlank() } ?: errorBody
+        } catch (ex: Exception) {
+            errorBody
+        }
+    }
+
     private fun currentIsoDateTime(): String {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             OffsetDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
@@ -130,3 +167,55 @@ class WorkOrdersRepository(
         const val DIVISION_FK = 1
     }
 }
+
+data class UserStatus(
+    val userId: Int,
+    val firstName: String,
+    val lastName: String,
+    val activeWorkOrder: ActiveWorkOrder?
+)
+
+data class ActiveWorkOrder(
+    val workOrderCollectionId: Int?,
+    val workOrderNumber: String?,
+    val workOrderAssemblyNumber: String?,
+    val clockInTime: String?,
+    val partNumber: String?,
+    val operationCode: String?,
+    val operationName: String?
+)
+
+private fun UserStatusResponse.toDomain(): UserStatus {
+    val hasActiveWorkOrder = workOrderCollectionId != null ||
+        !workOrderNumber.isNullOrBlank() ||
+        !workOrderAssemblyNumber.isNullOrBlank() ||
+        !clockInTime.isNullOrBlank() ||
+        !partNumber.isNullOrBlank() ||
+        !operationCode.isNullOrBlank() ||
+        !operationName.isNullOrBlank()
+
+    val activeWorkOrder = if (hasActiveWorkOrder) {
+        ActiveWorkOrder(
+            workOrderCollectionId = workOrderCollectionId,
+            workOrderNumber = workOrderNumber,
+            workOrderAssemblyNumber = workOrderAssemblyNumber,
+            clockInTime = clockInTime,
+            partNumber = partNumber,
+            operationCode = operationCode,
+            operationName = operationName
+        )
+    } else {
+        null
+    }
+
+    return UserStatus(
+        userId = userId,
+        firstName = firstName,
+        lastName = lastName,
+        activeWorkOrder = activeWorkOrder
+    )
+}
+
+private data class ErrorDetailResponse(
+    @SerializedName("detail") val detail: String?
+)


### PR DESCRIPTION
## Summary
- integrate the user validation endpoint to retrieve employee status and active work order data
- require successful employee validation before enabling Work Order entry and clock in/out actions
- update the Work Orders UI to present a guided two-step flow with employee details and validation feedback

## Testing
- ./gradlew test *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7f0fdfdc8331a3b7b2cef576657d