### PR TITLE
Preserve user ID formatting when calling backend

### DIFF
--- a/app/src/main/java/com/example/terminal/data/network/ApiService.kt
+++ b/app/src/main/java/com/example/terminal/data/network/ApiService.kt
@@ -14,5 +14,5 @@ interface ApiService {
     suspend fun clockOut(@Body request: ClockOutRequest): Response<ApiResponse>
 
     @GET("users/{userId}")
-    suspend fun getUserStatus(@Path("userId") userId: Int): Response<UserStatusResponse>
+    suspend fun getUserStatus(@Path("userId") userId: String): Response<UserStatusResponse>
 }

--- a/app/src/main/java/com/example/terminal/data/network/Models.kt
+++ b/app/src/main/java/com/example/terminal/data/network/Models.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 data class ClockInRequest(
     @SerializedName("workOrderAssemblyId") val workOrderAssemblyId: Int,
-    @SerializedName("userId") val userId: Int,
+    @SerializedName("userId") val userId: String,
     @SerializedName("divisionFK") val divisionFK: Int,
     @SerializedName("deviceDate") val deviceDate: String
 )

--- a/app/src/main/java/com/example/terminal/data/repository/WorkOrdersRepository.kt
+++ b/app/src/main/java/com/example/terminal/data/repository/WorkOrdersRepository.kt
@@ -23,7 +23,7 @@ class WorkOrdersRepository(
     private val userPrefs: UserPrefs,
     private val gson: Gson = Gson()
 ) {
-    suspend fun fetchUserStatus(userId: Int): Result<UserStatus> = withContext(Dispatchers.IO) {
+    suspend fun fetchUserStatus(userId: String): Result<UserStatus> = withContext(Dispatchers.IO) {
         val baseUrl = userPrefs.serverAddress.first()
         try {
             val apiService = ApiClient.getApiService(baseUrl)
@@ -45,7 +45,7 @@ class WorkOrdersRepository(
 
     suspend fun clockIn(
         workOrderAssemblyId: Int,
-        userId: Int
+        userId: String
     ): Result<ApiResponse> = withContext(Dispatchers.IO) {
         val baseUrl = userPrefs.serverAddress.first()
         try {

--- a/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersViewModel.kt
+++ b/app/src/main/java/com/example/terminal/ui/workorders/WorkOrdersViewModel.kt
@@ -122,16 +122,16 @@ class WorkOrdersViewModel(
             return
         }
 
-        val employeeId = employee.toIntOrNull()
-        val workOrderId = workOrder.toIntOrNull()
-        if (employeeId == null || workOrderId == null) {
+        if (!employee.isDigitsOnly() || !workOrder.isDigitsOnly()) {
             showMessage("Ingrese valores numéricos válidos")
             return
         }
 
+        val workOrderId = workOrder.toInt()
+
         setLoading(true)
         viewModelScope.launch {
-            val result = repository.clockIn(workOrderId, employeeId)
+            val result = repository.clockIn(workOrderId, employee)
             result.fold(
                 onSuccess = { response ->
                     val successMessage = response.message?.takeIf { it.isNotBlank() }
@@ -171,12 +171,12 @@ class WorkOrdersViewModel(
             return
         }
 
-        val employeeId = employee.toIntOrNull()
-        val workOrderId = workOrder.toIntOrNull()
-        if (employeeId == null || workOrderId == null) {
+        if (!employee.isDigitsOnly() || !workOrder.isDigitsOnly()) {
             showMessage("Ingrese valores numéricos válidos")
             return
         }
+
+        val workOrderId = workOrder.toInt()
 
         setLoading(true)
         _uiState.update { it.copy(showClockOutDialog = false) }
@@ -236,15 +236,14 @@ class WorkOrdersViewModel(
             return
         }
 
-        val employeeId = employee.toIntOrNull()
-        if (employeeId == null) {
+        if (!employee.isDigitsOnly()) {
             showMessage("Ingrese un número de empleado válido")
             return
         }
 
         setLoading(true)
         viewModelScope.launch {
-            val result = repository.fetchUserStatus(employeeId)
+            val result = repository.fetchUserStatus(employee)
             result.fold(
                 onSuccess = { status ->
                     _uiState.update {
@@ -292,3 +291,5 @@ class WorkOrdersViewModel(
         }
     }
 }
+
+private fun String.isDigitsOnly(): Boolean = isNotEmpty() && all(Char::isDigit)

--- a/backend/models.py
+++ b/backend/models.py
@@ -18,9 +18,15 @@ class ApiResponse(StrictBaseModel):
 
 class ClockInRequest(StrictBaseModel):
     workOrderAssemblyId: int
-    userId: int
+    userId: str
     divisionFK: Literal[1]
     deviceDate: str
+
+    @validator("userId")
+    def validate_user_id(cls, value: str) -> str:
+        if not value.isdigit():
+            raise ValueError("userId must contain only digits")
+        return value
 
     @validator("deviceDate")
     def validate_device_date(cls, value: str) -> str:


### PR DESCRIPTION
## Summary
- update the API and repository layers to send the userId as a String so leading zeros are kept intact
- adjust the work orders view model validation to keep the entered employee string while ensuring it only contains digits
- align the backend ClockInRequest schema with the new string-based userId validation

## Testing
- ./gradlew test *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dfcec698188331bb6b32f35cb3b81b