### PR TITLE
Add adjustable beep volume setting

### DIFF
--- a/app/src/main/java/com/example/terminal/data/local/UserPrefs.kt
+++ b/app/src/main/java/com/example/terminal/data/local/UserPrefs.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.example.terminal.data.network.ApiClient
@@ -13,6 +14,7 @@ import kotlinx.coroutines.flow.map
 private const val DATA_STORE_NAME = "user_prefs"
 private val LAST_EMPLOYEE_KEY = stringPreferencesKey("last_employee_id")
 private val SERVER_ADDRESS_KEY = stringPreferencesKey("server_address")
+private val BEEP_VOLUME_KEY = floatPreferencesKey("beep_volume")
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = DATA_STORE_NAME)
 
@@ -29,6 +31,11 @@ class UserPrefs private constructor(private val appContext: Context) {
             ApiClient.normalizeBaseUrl(savedAddress)
         }
 
+    val beepVolume: Flow<Float>
+        get() = appContext.dataStore.data.map { preferences ->
+            preferences[BEEP_VOLUME_KEY] ?: 1f
+        }
+
     suspend fun saveLastEmployeeId(employeeId: String) {
         appContext.dataStore.edit { preferences ->
             preferences[LAST_EMPLOYEE_KEY] = employeeId
@@ -39,6 +46,13 @@ class UserPrefs private constructor(private val appContext: Context) {
         val normalizedAddress = ApiClient.normalizeBaseUrl(address)
         appContext.dataStore.edit { preferences ->
             preferences[SERVER_ADDRESS_KEY] = normalizedAddress
+        }
+    }
+
+    suspend fun saveBeepVolume(volume: Float) {
+        val clampedVolume = volume.coerceIn(0f, 1f)
+        appContext.dataStore.edit { preferences ->
+            preferences[BEEP_VOLUME_KEY] = clampedVolume
         }
     }
 


### PR DESCRIPTION
## Summary
- add a persisted beep volume preference and apply it when playing keypad sounds
- extend the settings dialog with a slider to let users adjust the beep volume

## Testing
- ./gradlew test *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e01c2d4bf083318f6c5fa2d379e45c